### PR TITLE
B2BQUOTES-27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
 ### Added
 - Added on getQuote/getQuote a checker if the property b2b-quote-graphQL exists in the orderForm if not then it creates a new property there.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
 - Added on getQuote/getQuote a checker if the property b2b-quote-graphQL exists in the orderForm if not then it creates a new property there.
 
 ## [1.0.3] - 2022-01-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Added on getQuote/getQuote a checker if the property b2b-quote-graphQL exists in the orderForm if not then it creates a new property there.
 
 ## [1.0.3] - 2022-01-06
 

--- a/manifest.json
+++ b/manifest.json
@@ -12,10 +12,11 @@
   "dependencies": {
     "vtex.storefront-permissions": "1.x"
   },
-  "registries": [
-    "smartcheckout"
-  ],
+  "registries": ["smartcheckout"],
   "policies": [
+    {
+      "name": "vbase-read-write"
+    },
     {
       "name": "read-workspace-apps"
     },

--- a/node/clients/Checkout.ts
+++ b/node/clients/Checkout.ts
@@ -1,0 +1,52 @@
+import type {
+  InstanceOptions,
+  IOContext,
+  RequestTracingConfig,
+} from '@vtex/api'
+import { JanusClient } from '@vtex/api'
+
+import { createTracing } from '../utils/index'
+
+const CHECKOUT_ENDPOINT = 'api/checkout/pvt/configuration/orderForm'
+
+export const CHECKOUT_APP = 'b2b-quotes-graphql'
+
+export class Checkout extends JanusClient {
+  constructor(ctx: IOContext, options?: InstanceOptions) {
+    super(ctx, {
+      ...options,
+      headers: {
+        ...(ctx.adminUserAuthToken
+          ? {
+              VtexIdclientAutCookie: ctx.adminUserAuthToken,
+            }
+          : {}),
+      },
+    })
+  }
+
+  public getOrderFormConfiguration(tracingConfig?: RequestTracingConfig) {
+    const metric = `${CHECKOUT_APP}-getOrderForm`
+
+    return this.http.get<OrderFormConfiguration>(CHECKOUT_ENDPOINT, {
+      metric,
+      tracing: createTracing(metric, tracingConfig),
+    })
+  }
+
+  public setOrderFormConfiguration(
+    body: OrderFormConfiguration,
+    userToken: string,
+    tracingConfig?: RequestTracingConfig
+  ) {
+    const metric = `${CHECKOUT_APP}-setOrderForm`
+
+    return this.http.post(CHECKOUT_ENDPOINT, body, {
+      headers: {
+        VtexIdclientAutCookie: userToken,
+      },
+      metric,
+      tracing: createTracing(metric, tracingConfig),
+    })
+  }
+}

--- a/node/clients/index.ts
+++ b/node/clients/index.ts
@@ -4,6 +4,7 @@ import RequestHub from '../utils/Hub'
 import StorefrontPermissions from './storefrontPermissions'
 import VtexId from './vtexId'
 import Organizations from './organizations'
+import { Checkout } from './Checkout'
 
 // Extend the default IOClients implementation with our own custom clients.
 export class Clients extends IOClients {
@@ -13,6 +14,10 @@ export class Clients extends IOClients {
 
   public get vtexId() {
     return this.getOrSet('vtexId', VtexId)
+  }
+
+  public get checkout() {
+    return this.getOrSet('checkout', Checkout)
   }
 
   public get organizations() {

--- a/node/resolvers/index.ts
+++ b/node/resolvers/index.ts
@@ -919,7 +919,7 @@ export const resolvers = {
           })
           .catch((e) =>
             logger.error({
-              message: 'useQuote-error',
+              message: 'useQuote-addCustomDataError',
               e,
             })
           )

--- a/node/resolvers/index.ts
+++ b/node/resolvers/index.ts
@@ -52,8 +52,15 @@ const routes = {
     `${routes.orderForm(account)}/${id}/items/removeAll`,
   addToCart: (account: string, orderFormId: string) =>
     `${routes.orderForm(account)}/${orderFormId}/items/`,
-  addCustomData: (account: string, orderFormId: string, appId: string) =>
-    `${routes.orderForm(account)}/${orderFormId}/customData/${appId}`,
+  addCustomData: (
+    account: string,
+    orderFormId: string,
+    appId: string,
+    property?: string
+  ) =>
+    `${routes.orderForm(account)}/${orderFormId}/customData/${appId}/${
+      property ?? ''
+    }`,
   addPriceToItems: (account: string, orderFormId: string) =>
     `${routes.orderForm(account)}/${orderFormId}/items/update`,
 }
@@ -877,6 +884,25 @@ export const resolvers = {
 
           orderFormId = (newOrderForm.data as any).orderFormId
         }
+
+        await checkAndCreateQuotesConfig(ctx)
+        await hub
+          .put(
+            routes.addCustomData(account, orderFormId, CHECKOUT_APP, 'quoteId'),
+            {
+              value: id,
+            },
+            useHeaders
+          )
+          .then((res: any) => {
+            return res.data
+          })
+          .catch((e) =>
+            logger.error({
+              message: 'useQuote-error',
+              e,
+            })
+          )
 
         // ADD ITEMS TO CART
         const data = await hub

--- a/node/typings.d.ts
+++ b/node/typings.d.ts
@@ -41,3 +41,17 @@ declare module '*.json' {
   const value: any
   export default value
 }
+
+interface OrderFormConfiguration {
+  paymentConfiguration?: PaymentConfiguration
+  taxConfiguration?: TaxConfiguration
+  minimumQuantityAccumulatedForItems?: number
+  decimalDigitsPrecision?: number
+  minimumValueAccumulated?: number
+  apps?: [App]
+  allowMultipleDeliveries?: boolean
+  allowManualPrice?: boolean
+  maxIntOfWhiteLabelSellers?: number
+  maskFirstPurchaseData?: boolean
+  recaptchaValidation?: boolean
+}

--- a/node/utils/index.ts
+++ b/node/utils/index.ts
@@ -1,0 +1,42 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import * as crypto from 'crypto'
+
+import type { AxiosError } from 'axios'
+import type { RequestTracingConfig } from '@vtex/api'
+import { AuthenticationError, ForbiddenError, UserInputError } from '@vtex/api'
+
+export const toHash = (obj: any) => {
+  return crypto.createHash('md5').update(JSON.stringify(obj)).digest('hex')
+}
+
+export function statusToError(e: any) {
+  if (!e.response) {
+    throw e
+  }
+
+  const { response } = e as AxiosError
+  const { status } = response!
+
+  if (status === 401) {
+    throw new AuthenticationError(e)
+  }
+
+  if (status === 403) {
+    throw new ForbiddenError(e)
+  }
+
+  if (status === 400) {
+    throw new UserInputError(e)
+  }
+
+  throw e
+}
+
+export const createTracing = (
+  metric: string,
+  tracingConfig?: RequestTracingConfig
+) => ({
+  requestSpanNameSuffix: metric,
+  ...tracingConfig?.tracing,
+})


### PR DESCRIPTION
Added on getQuote/getQuote a checker if the configuration property b2b-quote-graphQL exists in the orderForm if not then it creates a new property there.

#### What problem is this solving?

This feature is in charge of creating a configuration property called by b2b-quotes-graphql into the orderForm, so it checks if the property is configured and then if not it'll be created.
Also, this checker will execute on getQuote/getQuotes GraphQL calls.

#### How to test it?

This feature has been linked on this URL [https://artur--b2bstoreqa.myvtex.com/](https://artur--b2bstoreqa.myvtex.com/).

1) To be tested properly you have to clone this repository and checkout the current branch (feature/order-form-property) and then link the app in another workspace that you want (different from "artur").
2) Access the url from your workspace
3) Go to this url: <workspace>b2bstoreqa.myvtex.com/b2b-quotes
4) Use this credential: kevin.yee@vtex.com / Vtex1234
5) The page will be reloaded and then you can access the list of quotes
6) Access some quote and than click at "Use Quote" button at the bottom of page
7) You'll be redirected to the checkout page, so you can check the property by accessing the orderForm custom data, Chrome console:  ```window.vtexjs.checkout.orderForm.customData.customApps ```