### PR TITLE
[B2BQUOTES-40] Fix search and filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Search list of quotes by reference name or creator email and filter by cost center name
+
 ## [1.4.0] - 2022-03-10
 
 ### Added


### PR DESCRIPTION
#### What problem is this solving?

This PR makes quotes search and filtering functional. 

For search, previous version attempted to use MD's "keyword" functionality which is not supported by the built-in MD client. This PR performs a search using the "where" clause instead.

For filtering, previous version had a bug having to do with async/await. The code would build an array of cost center IDs, but the array would be used before the promises completed, and the array was therefore empty. This PR solves the bug through use of Promise.all().

#### How to test it?

New version linked here: https://b2bsuite--sandboxusdev.myvtex.com

Log in as an organization user and go to https://b2bsuite--sandboxusdev.myvtex.com/b2b-quotes 
Then, either search for a quote name or creator email, or use the filter (click More, choose Cost Center, and enter a cost center name). 