### PR TITLE
[B2BQUOTES-48] Use org/cost center ID instead of name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `getQuotes` now expects `organization` and `costCenter` variables to be arrays of IDs rather than names
+
 ## [2.0.0] - 2022-04-12
 
 ### Changed

--- a/node/package.json
+++ b/node/package.json
@@ -14,7 +14,7 @@
     "@types/jsonwebtoken": "^8.5.0",
     "@types/node": "^12.0.0",
     "@types/ramda": "types/npm-ramda#dist",
-    "@vtex/api": "6.45.11-beta",
+    "@vtex/api": "6.45.12",
     "@vtex/prettier-config": "^0.3.1",
     "tslint": "^5.12.0",
     "tslint-config-prettier": "^1.18.0",

--- a/node/resolvers/queries/index.ts
+++ b/node/resolvers/queries/index.ts
@@ -31,12 +31,7 @@ const buildWhereStatement = async ({
   if (!permissions.includes('access-quotes-all')) {
     whereArray.push(`organization=${userOrganizationId}`)
   } else if (organization?.length) {
-    // if user is filtering by organization name, look up organization ID
-    const orgArray = [] as string[]
-
-    organization.forEach(async (org) => {
-      orgArray.push(`organization=${org}`)
-    })
+    const orgArray = organization.map((org) => `organization=${org}`)
     const organizationsStatement = `(${orgArray.join(' OR ')})`
 
     whereArray.push(organizationsStatement)
@@ -50,23 +45,14 @@ const buildWhereStatement = async ({
   ) {
     whereArray.push(`costCenter=${userCostCenterId}`)
   } else if (costCenter?.length) {
-    // if user is filtering by cost center name, look up cost center ID
-    const ccArray = [] as string[]
-
-    costCenter.forEach((cc) => {
-      ccArray.push(`costCenter=${cc}`)
-    })
+    const ccArray = costCenter.map((cc) => `costCenter=${cc}`)
     const costCenters = `(${ccArray.join(' OR ')})`
 
     whereArray.push(costCenters)
   }
 
   if (status?.length) {
-    const statusArray = [] as string[]
-
-    status.forEach((stat) => {
-      statusArray.push(`status=${stat}`)
-    })
+    const statusArray = status.map((stat) => `status=${stat}`)
     const statuses = `(${statusArray.join(' OR ')})`
 
     whereArray.push(statuses)

--- a/node/resolvers/queries/index.ts
+++ b/node/resolvers/queries/index.ts
@@ -15,7 +15,6 @@ const buildWhereStatement = async ({
   search,
   userOrganizationId,
   userCostCenterId,
-  ctx,
 }: {
   permissions: string[]
   organization?: string[]
@@ -24,12 +23,7 @@ const buildWhereStatement = async ({
   search?: string
   userOrganizationId: string
   userCostCenterId: string
-  ctx: Context
 }) => {
-  const {
-    clients: { organizations },
-  } = ctx
-
   const whereArray = []
 
   // if user only has permission to access their organization's quotes,
@@ -41,15 +35,7 @@ const buildWhereStatement = async ({
     const orgArray = [] as string[]
 
     organization.forEach(async (org) => {
-      const organizationResult = await organizations.getOrganizationIDs(org)
-
-      if (organizationResult?.data?.getOrganizations?.data?.length > 0) {
-        organizationResult.data.getOrganizations.data.forEach(
-          (element: any) => {
-            orgArray.push(`organization=${element.id}`)
-          }
-        )
-      }
+      orgArray.push(`organization=${org}`)
     })
     const organizationsStatement = `(${orgArray.join(' OR ')})`
 
@@ -66,20 +52,9 @@ const buildWhereStatement = async ({
   } else if (costCenter?.length) {
     // if user is filtering by cost center name, look up cost center ID
     const ccArray = [] as string[]
-    const promises = [] as Array<Promise<unknown>>
 
     costCenter.forEach((cc) => {
-      promises.push(organizations.getCostCenterIDs(cc))
-    })
-
-    const results = await Promise.all(promises)
-
-    results.forEach((costCenterResult: any) => {
-      if (costCenterResult?.data?.getCostCenters?.data?.length > 0) {
-        costCenterResult.data.getCostCenters.data.forEach((element: any) => {
-          ccArray.push(`costCenter=${element.id}`)
-        })
-      }
+      ccArray.push(`costCenter=${cc}`)
     })
     const costCenters = `(${ccArray.join(' OR ')})`
 
@@ -249,7 +224,6 @@ export const Query = {
       search,
       userOrganizationId,
       userCostCenterId,
-      ctx,
     })
 
     try {

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -173,10 +173,10 @@
     "@types/mime" "^1"
     "@types/node" "*"
 
-"@vtex/api@6.45.11-beta":
-  version "6.45.11-beta"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.11-beta.tgz#edc51a2fdd3903f33caf7d63f198005f0d5a0c98"
-  integrity sha512-BFHMWU4SEFKXpbW3TWj0CI944p9ysmoCtB8ewpQlyRpUZFhPx2On/qFgBrD+Gqwt1yvysuKIAOfzfpjqKy88Gg==
+"@vtex/api@6.45.12":
+  version "6.45.12"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.12.tgz#b13c04398b12f576263ea823369f09c970d57479"
+  integrity sha512-SVLKo+Q/TxQy+1UKzH8GswTI3F2OCRCLfgaNQOrVAVdbM6Ci4wzTeX8j/S4Q1aEEnqBFlH/wVpHf8I6NBa+g9A==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -197,7 +197,7 @@
     graphql "^14.5.8"
     graphql-tools "^4.0.6"
     graphql-upload "^8.1.0"
-    jaeger-client "^3.19.0"
+    jaeger-client "^3.18.0"
     js-base64 "^2.5.1"
     koa "^2.11.0"
     koa-compose "^4.1.0"
@@ -207,7 +207,7 @@
     mime-types "^2.1.12"
     opentracing "^0.14.4"
     p-limit "^2.2.0"
-    prom-client "^14.0.1"
+    prom-client "^12.0.0"
     qs "^6.5.1"
     querystring "^0.2.0"
     ramda "^0.26.0"
@@ -957,7 +957,7 @@ iterall@^1.1.3, iterall@^1.2.2:
   resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.3.0.tgz#afcb08492e2915cbd8a0884eb93a8c94d0d72fea"
   integrity sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==
 
-jaeger-client@^3.19.0:
+jaeger-client@^3.18.0:
   version "3.19.0"
   resolved "https://registry.yarnpkg.com/jaeger-client/-/jaeger-client-3.19.0.tgz#9b5bd818ebd24e818616ee0f5cffe1722a53ae6e"
   integrity sha512-M0c7cKHmdyEUtjemnJyx/y9uX16XHocL46yQvyqDlPdvAcwPDbHrIbKjQdBqtiE4apQ/9dmr+ZLJYYPGnurgpw==
@@ -1342,10 +1342,10 @@ process@^0.10.0:
   resolved "https://registry.yarnpkg.com/process/-/process-0.10.1.tgz#842457cc51cfed72dc775afeeafb8c6034372725"
   integrity sha1-hCRXzFHP7XLcd1r+6vuMYDQ3JyU=
 
-prom-client@^14.0.1:
-  version "14.0.1"
-  resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-14.0.1.tgz#bdd9583e02ec95429677c0e013712d42ef1f86a8"
-  integrity sha512-HxTArb6fkOntQHoRGvv4qd/BkorjliiuO2uSWC2KC17MUTKYttWdDoXX/vxOhQdkoECEM9BBH0pj2l8G8kev6w==
+prom-client@^12.0.0:
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-12.0.0.tgz#9689379b19bd3f6ab88a9866124db9da3d76c6ed"
+  integrity sha512-JbzzHnw0VDwCvoqf8y1WDtq4wSBAbthMB1pcVI/0lzdqHGJI3KBJDXle70XK+c7Iv93Gihqo0a5LlOn+g8+DrQ==
   dependencies:
     tdigest "^0.1.1"
 


### PR DESCRIPTION
#### What problem is this solving?

Previously, to support filtering the frontend quotes table by organization or cost center, the frontend would provide the organization or cost center's name. Since two orgs or cost centers can have the same name, this app included logic to look up the ID(s) that corresponded to the name in question. However, if there were many orgs or cost centers with the same name, this could cause the Masterdata search to fail due to hitting a query string character limit. 

To fix this issue, this PR changes the query resolver to expect an array of IDs for the organization and cost center, rather than names. The frontend will be responsible for determining the IDs of the organization and cost center that the user has chosen to filter by (pending a related PR on `vtex.b2b-quotes`). 

#### How to test it?

New versions of `b2b-quotes` and `b2b-quotes-graphql` linked here: https://b2bsuite--sandboxusdev.myvtex.com

The `b2b-quotes` PR will have more information on how to test.