### PR TITLE
GitHub push actions triggered only for VTEX-IO on master/main

### DIFF
--- a/.github/workflows/qe-push.yml
+++ b/.github/workflows/qe-push.yml
@@ -5,14 +5,6 @@ on:
     branches: 
       - master
       - main
-      - bugfix/*
-      - chore/*
-      - enhancement/*
-      - feature/*
-      - fix/*
-      - hotfix/*
-      - translation/*
-      - actions/*
 
 jobs:
   quality-engineering:


### PR DESCRIPTION
#### What problem is this solving?

Allow push actions only on main/master branches to save processing time.