### PR TITLE
[B2BQUOTES-68][B2BQUOTES-69] Save sales channel in quotes, Filter quotes by sales channel, Apply sales channel when using quote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Store sales channel information in Quotes
+- Apply stored sales channel in cart when using Quotes
+- Consider permission to view Quotes according to stored sales channel
+
 ## [2.0.2] - 2022-08-03
 
 ### Fixed

--- a/graphql/directives.graphql
+++ b/graphql/directives.graphql
@@ -1,2 +1,3 @@
 directive @withSession on FIELD | FIELD_DEFINITION
 directive @withPermissions on FIELD | FIELD_DEFINITION
+directive @withSegment on FIELD | FIELD_DEFINITION

--- a/graphql/quote.graphql
+++ b/graphql/quote.graphql
@@ -58,6 +58,7 @@ type Quote {
   costCenterName: String
   viewedBySales: Boolean
   viewedByCustomer: Boolean
+  salesChannel: String
 }
 
 type QuoteUpdate {

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -3,6 +3,7 @@ type Query {
   getQuote(id: String): Quote
     @withPermissions
     @withSession
+    @withSegment
     @cacheControl(scope: PRIVATE, maxAge: SHORT)
   getQuotes(
     organization: [String]
@@ -16,11 +17,12 @@ type Query {
   ): Quotes
     @withPermissions
     @withSession
+    @withSegment
     @cacheControl(scope: PRIVATE, maxAge: SHORT)
 }
 
 type Mutation {
-  createQuote(input: QuoteInput!): String @withPermissions @withSession
+  createQuote(input: QuoteInput!): String @withPermissions @withSession @withSegment
   updateQuote(input: QuoteUpdateInput!): String @withPermissions @withSession
   useQuote(id: String, orderFormId: String): String
     @withPermissions

--- a/node/constants.ts
+++ b/node/constants.ts
@@ -19,6 +19,7 @@ export const QUOTE_FIELDS = [
   'costCenter',
   'viewedBySales',
   'viewedByCustomer',
+  'salesChannel',
 ]
 
 export const routes = {
@@ -107,6 +108,10 @@ export const schema = {
       title: 'Reference Name',
       type: 'string',
     },
+    salesChannel: {
+      title: 'Sales Channel',
+      type: ['null', 'string'],
+    },
     status: {
       title: 'Status',
       type: 'string',
@@ -149,5 +154,6 @@ export const schema = {
     'status',
     'organization',
     'costCenter',
+    'salesChannel',
   ],
 }

--- a/node/constants.ts
+++ b/node/constants.ts
@@ -1,5 +1,5 @@
 export const APP_NAME = 'b2b-quotes-graphql'
-export const SCHEMA_VERSION = 'v1.2'
+export const SCHEMA_VERSION = 'v1.3'
 export const QUOTE_DATA_ENTITY = 'quotes'
 export const CRON_EXPRESSION = '0 */12 * * *'
 

--- a/node/package.json
+++ b/node/package.json
@@ -6,9 +6,11 @@
     "graphql": "^14.0.0",
     "graphql-tools": "^4.0.0",
     "jsonwebtoken": "^8.5.0",
-    "ramda": "^0.25.0"
+    "ramda": "^0.25.0",
+    "atob": "^2.1.2"
   },
   "devDependencies": {
+    "@types/atob": "^2.1.2",
     "@types/bluebird": "^3.5.25",
     "@types/co-body": "0.0.3",
     "@types/jsonwebtoken": "^8.5.0",
@@ -20,9 +22,9 @@
     "tslint-config-prettier": "^1.18.0",
     "tslint-config-vtex": "^2.1.0",
     "typescript": "3.9.7",
-    "vtex.b2b-quotes-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.b2b-quotes-graphql@1.4.2/public/@types/vtex.b2b-quotes-graphql",
-    "vtex.orders-broadcast": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.orders-broadcast@0.2.2/public/_types/react",
-    "vtex.storefront-permissions": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.storefront-permissions@1.14.3/public/@types/vtex.storefront-permissions"
+    "vtex.b2b-quotes-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.b2b-quotes-graphql@2.0.2/public/@types/vtex.b2b-quotes-graphql",
+    "vtex.orders-broadcast": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.orders-broadcast@0.3.0/public/_types/react",
+    "vtex.storefront-permissions": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.storefront-permissions@1.23.0/public/@types/vtex.storefront-permissions"
   },
   "scripts": {
     "lint": "tsc --noEmit && tslint -c tslint.json './**/*.ts'"

--- a/node/resolvers/directives.ts
+++ b/node/resolvers/directives.ts
@@ -1,7 +1,10 @@
 import { WithPermissions } from './directives/withPermissions'
 import { WithSession } from './directives/withSession'
+import { WithSegment } from './directives/withSegment'
+
 
 export const schemaDirectives = {
   withPermissions: WithPermissions as any,
   withSession: WithSession as any,
+  withSegment: WithSegment as any,
 }

--- a/node/resolvers/directives.ts
+++ b/node/resolvers/directives.ts
@@ -2,7 +2,6 @@ import { WithPermissions } from './directives/withPermissions'
 import { WithSession } from './directives/withSession'
 import { WithSegment } from './directives/withSegment'
 
-
 export const schemaDirectives = {
   withPermissions: WithPermissions as any,
   withSession: WithSession as any,

--- a/node/resolvers/directives/withSegment.ts
+++ b/node/resolvers/directives/withSegment.ts
@@ -16,8 +16,8 @@ export class WithSegment extends SchemaDirectiveVisitor {
       } = context
 
       context.vtex.segmentData = segmentToken
-      ? JSON.parse(atob(segmentToken))
-      : await segment.getSegment()
+        ? JSON.parse(atob(segmentToken))
+        : await segment.getSegment()
 
       return resolve(root, args, context, info)
     }

--- a/node/resolvers/directives/withSegment.ts
+++ b/node/resolvers/directives/withSegment.ts
@@ -1,0 +1,25 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable max-params */
+import type { GraphQLField } from 'graphql'
+import { defaultFieldResolver } from 'graphql'
+import { SchemaDirectiveVisitor } from 'graphql-tools'
+import atob from 'atob'
+
+export class WithSegment extends SchemaDirectiveVisitor {
+  public visitFieldDefinition(field: GraphQLField<any, any>) {
+    const { resolve = defaultFieldResolver } = field
+
+    field.resolve = async (root: any, args: any, context: any, info: any) => {
+      const {
+        clients: { segment },
+        vtex: { segmentToken },
+      } = context
+
+      context.vtex.segmentData = segmentToken
+      ? JSON.parse(atob(segmentToken))
+      : await segment.getSegment()
+
+      return resolve(root, args, context, info)
+    }
+  }
+}

--- a/node/resolvers/mutations/index.ts
+++ b/node/resolvers/mutations/index.ts
@@ -69,7 +69,7 @@ export const Mutation = {
       vtex: { logger },
     } = ctx
 
-    const { sessionData, storefrontPermissions } = vtex as any
+    const { sessionData, storefrontPermissions, segmentData } = vtex as any
 
     const settings = await checkConfig(ctx)
 
@@ -110,6 +110,8 @@ export const Mutation = {
       },
     ]
 
+    const salesChannel: string = segmentData?.channel
+
     const quote = {
       costCenter: costCenterId,
       creationDate: nowISO,
@@ -125,6 +127,7 @@ export const Mutation = {
       updateHistory,
       viewedByCustomer: sendToSalesRep,
       viewedBySales: !sendToSalesRep,
+      salesChannel,
     }
 
     try {
@@ -365,7 +368,7 @@ export const Mutation = {
 
       checkQuoteStatus(quote)
 
-      const { items } = quote
+      const { items, salesChannel } = quote
 
       // CLEAR CURRENT CART
       if (orderFormId !== 'default-order-form') {
@@ -412,9 +415,11 @@ export const Mutation = {
           })
         )
 
+      const salesChannelQueryString = salesChannel ? `?sc=${salesChannel}` : ''
+
       // ADD ITEMS TO CART
       const data = await hub
-        .post(routes.addToCart(account, orderFormId), {
+        .post(`${routes.addToCart(account, orderFormId)}${salesChannelQueryString}`, {
           expectedOrderFormSections: ['items'],
           orderItems: items.map((item) => {
             return {

--- a/node/resolvers/mutations/index.ts
+++ b/node/resolvers/mutations/index.ts
@@ -419,16 +419,19 @@ export const Mutation = {
 
       // ADD ITEMS TO CART
       const data = await hub
-        .post(`${routes.addToCart(account, orderFormId)}${salesChannelQueryString}`, {
-          expectedOrderFormSections: ['items'],
-          orderItems: items.map((item) => {
-            return {
-              id: item.id,
-              quantity: item.quantity,
-              seller: item.seller || '1',
-            }
-          }),
-        })
+        .post(
+          `${routes.addToCart(account, orderFormId)}${salesChannelQueryString}`,
+          {
+            expectedOrderFormSections: ['items'],
+            orderItems: items.map((item) => {
+              return {
+                id: item.id,
+                quantity: item.quantity,
+                seller: item.seller || '1',
+              }
+            }),
+          }
+        )
         .then((res: any) => {
           return res.data
         })

--- a/node/resolvers/queries/index.ts
+++ b/node/resolvers/queries/index.ts
@@ -55,12 +55,13 @@ const buildWhereStatement = async ({
 
   // similarly, if user only has permission to see their quotes from their sales channel,
   // hard-code its value into the search
+  // allow all users to view quotes without a sales channel
   if (
     !permissions.includes('access-quotes-all') && 
     !permissions.includes('access-quotes-all-saleschannel') && 
     userSalesChannel
   ) {
-    whereArray.push(`salesChannel="${userSalesChannel}"`)
+    whereArray.push(`((salesChannel is null) OR salesChannel="${userSalesChannel}")`)
   }
 
   if (status?.length) {
@@ -145,10 +146,11 @@ export const Query = {
         return null
       }
 
-      // if user only has permission to view quotes from their sales channel, check that the sales channel matches
+      // if user only has permission to view quotes from their sales channel, check that the sales channel matches or is null
       if (
         !permissions.includes('access-quotes-all') &&
         !permissions.includes('access-quotes-all-saleschannel') &&
+        quote.salesChannel && 
         userSalesChannel !== quote.salesChannel
       ) {
         return null

--- a/node/resolvers/queries/index.ts
+++ b/node/resolvers/queries/index.ts
@@ -57,11 +57,13 @@ const buildWhereStatement = async ({
   // hard-code its value into the search
   // allow all users to view quotes without a sales channel
   if (
-    !permissions.includes('access-quotes-all') && 
-    !permissions.includes('access-quotes-all-saleschannel') && 
+    !permissions.includes('access-quotes-all') &&
+    !permissions.includes('access-quotes-all-saleschannel') &&
     userSalesChannel
   ) {
-    whereArray.push(`((salesChannel is null) OR salesChannel="${userSalesChannel}")`)
+    whereArray.push(
+      `((salesChannel is null) OR salesChannel="${userSalesChannel}")`
+    )
   }
 
   if (status?.length) {
@@ -150,7 +152,7 @@ export const Query = {
       if (
         !permissions.includes('access-quotes-all') &&
         !permissions.includes('access-quotes-all-saleschannel') &&
-        quote.salesChannel && 
+        quote.salesChannel &&
         userSalesChannel !== quote.salesChannel
       ) {
         return null

--- a/node/resolvers/queries/index.ts
+++ b/node/resolvers/queries/index.ts
@@ -15,6 +15,7 @@ const buildWhereStatement = async ({
   search,
   userOrganizationId,
   userCostCenterId,
+  userSalesChannel,
 }: {
   permissions: string[]
   organization?: string[]
@@ -23,6 +24,7 @@ const buildWhereStatement = async ({
   search?: string
   userOrganizationId: string
   userCostCenterId: string
+  userSalesChannel?: string
 }) => {
   const whereArray = []
 
@@ -49,6 +51,16 @@ const buildWhereStatement = async ({
     const costCenters = `(${ccArray.join(' OR ')})`
 
     whereArray.push(costCenters)
+  }
+
+  // similarly, if user only has permission to see their quotes from their sales channel,
+  // hard-code its value into the search
+  if (
+    !permissions.includes('access-quotes-all') && 
+    !permissions.includes('access-quotes-all-saleschannel') && 
+    userSalesChannel
+  ) {
+    whereArray.push(`salesChannel="${userSalesChannel}"`)
   }
 
   if (status?.length) {
@@ -79,7 +91,7 @@ export const Query = {
       vtex: { logger },
     } = ctx
 
-    const { sessionData, storefrontPermissions } = vtex as any
+    const { sessionData, storefrontPermissions, segmentData } = vtex as any
 
     if (
       !storefrontPermissions?.permissions?.length ||
@@ -95,6 +107,8 @@ export const Query = {
 
     const userCostCenterId =
       sessionData.namespaces['storefront-permissions'].costcenter.value
+
+    const userSalesChannel = segmentData?.channel
 
     if (
       !permissions.some(
@@ -127,6 +141,15 @@ export const Query = {
         !permissions.includes('access-quotes-all') &&
         !permissions.includes('access-quotes-organization') &&
         userCostCenterId !== quote.costCenter
+      ) {
+        return null
+      }
+
+      // if user only has permission to view quotes from their sales channel, check that the sales channel matches
+      if (
+        !permissions.includes('access-quotes-all') &&
+        !permissions.includes('access-quotes-all-saleschannel') &&
+        userSalesChannel !== quote.salesChannel
       ) {
         return null
       }
@@ -175,7 +198,7 @@ export const Query = {
       vtex: { logger },
     } = ctx
 
-    const { sessionData, storefrontPermissions } = vtex as any
+    const { sessionData, storefrontPermissions, segmentData } = vtex as any
 
     if (
       !storefrontPermissions?.permissions?.length ||
@@ -200,6 +223,8 @@ export const Query = {
       return null
     }
 
+    const userSalesChannel = segmentData?.channel
+
     await checkConfig(ctx)
 
     const where = await buildWhereStatement({
@@ -210,6 +235,7 @@ export const Query = {
       search,
       userOrganizationId,
       userCostCenterId,
+      userSalesChannel,
     })
 
     try {

--- a/node/typings.d.ts
+++ b/node/typings.d.ts
@@ -14,6 +14,7 @@ interface Quote {
   costCenter: string
   viewedBySales: boolean
   viewedByCustomer: boolean
+  salesChannel: string | null
 }
 
 interface QuoteUpdate {

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -30,6 +30,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/atob@^2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@types/atob/-/atob-2.1.2.tgz#157eb0cc46264a8c55f2273a836c7a1a644fb820"
+  integrity sha512-8GAYQ1jDRUQkSpHzJUqXwAkYFOxuWAOGLhIR4aPd/Y/yL12Q/9m7LsKpHKlfKdNE/362Hc9wPI1Yh6opDfxVJg==
+
 "@types/bluebird@^3.5.25":
   version "3.5.36"
   resolved "https://registry.yarnpkg.com/@types/bluebird/-/bluebird-3.5.36.tgz#00d9301d4dc35c2f6465a8aec634bb533674c652"
@@ -339,6 +344,11 @@ async@^2.6.3:
   integrity sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==
   dependencies:
     lodash "^4.17.14"
+
+atob@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
+  integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
 axios-retry@^3.1.2:
   version "3.1.9"
@@ -1473,7 +1483,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:
@@ -1688,17 +1698,17 @@ vary@^1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
 
-"vtex.b2b-quotes-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.b2b-quotes-graphql@1.4.2/public/@types/vtex.b2b-quotes-graphql":
-  version "1.4.2"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.b2b-quotes-graphql@1.4.2/public/@types/vtex.b2b-quotes-graphql#4425bef327a3e08724db9434b58dc39d6f650ef7"
+"vtex.b2b-quotes-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.b2b-quotes-graphql@2.0.2/public/@types/vtex.b2b-quotes-graphql":
+  version "2.0.2"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.b2b-quotes-graphql@2.0.2/public/@types/vtex.b2b-quotes-graphql#cae630894931ecbaf90b464e70af64fe69f51575"
 
-"vtex.orders-broadcast@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.orders-broadcast@0.2.2/public/_types/react":
+"vtex.orders-broadcast@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.orders-broadcast@0.3.0/public/_types/react":
   version "0.0.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.orders-broadcast@0.2.2/public/_types/react#fa7a0347e046eab3dd768998fc9252b2c0dd5aef"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.orders-broadcast@0.3.0/public/_types/react#fa7a0347e046eab3dd768998fc9252b2c0dd5aef"
 
-"vtex.storefront-permissions@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.storefront-permissions@1.14.3/public/@types/vtex.storefront-permissions":
-  version "1.14.3"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.storefront-permissions@1.14.3/public/@types/vtex.storefront-permissions#4e5ca034baa0d86ce8ead33c87a9a018520c983d"
+"vtex.storefront-permissions@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.storefront-permissions@1.23.0/public/@types/vtex.storefront-permissions":
+  version "1.23.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.storefront-permissions@1.23.0/public/@types/vtex.storefront-permissions#2a12e48a1b630d6d9cd64115572bcae55a7aa756"
 
 wrappy@1:
   version "1.0.2"


### PR DESCRIPTION
#### What problem is this solving?

- Store sales channel information in Quotes
- Apply stored sales channel in cart when using Quotes, if available
- Add permission to view all Quotes from all sales channels (except when Quote is restricted from viewing by other conditions). When this permission is disabled for a role, users with that role will only be able to see Quotes with sales channel equal to their current sales channel (according to `channel` value in `vtex_segment`) or when sales channel is `null`

#### How to test it?

Test in workspace [anna](https://anna--b2bstoreqa.myvtex.com/) in account b2bstoreqa.

#### Screenshots or example usage:

_Sales Representative_ role without permission for `Access All Sales Channels' Quotes and Carts`
<img width="977" alt="Screen Shot 2022-08-23 at 12 42 15 PM" src="https://user-images.githubusercontent.com/53097865/186215128-3d179275-7920-46fd-a343-425c60a449e1.png">

Current user's sales channel is "1" and _Anna Test Quote_ 12 to 17 were created with sc=1 (in red). _Anna Test Quote_ 6 to 11 have sc=null (in blue)
<img width="1440" alt="Screen Shot 2022-08-23 at 12 43 52 PM" src="https://user-images.githubusercontent.com/53097865/186215276-846fda8d-bf6a-409c-891e-6752f634b5e1.png">

<img width="458" alt="Screen Shot 2022-08-23 at 12 45 15 PM" src="https://user-images.githubusercontent.com/53097865/186216263-6717d39d-c7e0-4148-b723-66c2e002c78a.png">

#### Related to / Depends on
Adding new feature/permission for `Access All Sales Channels' Quotes and Carts` in vtex.b2b-quotes [configuration.json](https://github.com/vtex-apps/b2b-quotes/blob/master/vtex.storefront-permissions/configuration.json).