### PR TITLE
[B2BQUOTES-78] fix decline quote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed updateQuote graphql about declining a quote
+
 ## [2.2.1] - 2022-11-11
 
 ### Changed

--- a/node/resolvers/mutations/index.ts
+++ b/node/resolvers/mutations/index.ts
@@ -276,6 +276,7 @@ export const Mutation = {
       const data = await masterdata
         .updateEntireDocument({
           dataEntity: QUOTE_DATA_ENTITY,
+          schema: SCHEMA_VERSION,
           fields: updatedQuote,
           id,
         })


### PR DESCRIPTION
#### What problem is this solving?

When declining quotes, the updateQuote graphql remove the data schema information, so that the data entry does not show for search. This PR fix this problem by adding the schema in the updated information. 

#### How to test it?

[Workspace](https://aurora--b2bstoreqa.myvtex.com/b2b-quotes)
1. create a quote
2. decline the quote 
3. you should see the declined quote showing

