### PR TITLE
Fix: add new ListOrders policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `ListOrders` policy
+
 ## [2.2.2] - 2023-01-10
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -13,15 +13,16 @@
     "vtex.storefront-permissions": "1.x",
     "vtex.orders-broadcast": "0.x"
   },
-  "registries": [
-    "smartcheckout"
-  ],
+  "registries": ["smartcheckout"],
   "policies": [
     {
       "name": "vbase-read-write"
     },
     {
       "name": "OMSViewer"
+    },
+    {
+      "name": "ListOrders"
     },
     {
       "name": "read-workspace-apps"


### PR DESCRIPTION
#### What problem is this solving?

Adds policy required by new version of OMS: https://vtex.slack.com/archives/C91LXBHLK/p1675291291484189