### PR TITLE
fix: use the account to get the token in the header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Use the account to get the token in the header and send it to clear the cart and order
+
 ## [2.3.0] - 2023-08-14
 
 ### Added

--- a/node/package.json
+++ b/node/package.json
@@ -17,7 +17,7 @@
     "@types/jsonwebtoken": "^8.5.0",
     "@types/node": "^12.0.0",
     "@types/ramda": "types/npm-ramda#dist",
-    "@vtex/api": "6.45.19",
+    "@vtex/api": "6.45.20",
     "@vtex/prettier-config": "^0.3.1",
     "tslint": "^5.12.0",
     "tslint-config-prettier": "^1.18.0",

--- a/node/resolvers/mutations/index.ts
+++ b/node/resolvers/mutations/index.ts
@@ -359,7 +359,7 @@ export const Mutation = {
       throw new GraphQLError('operation-not-permitted')
     }
 
-    const token = ctx.cookies.get(`VtexIdclientAutCookie_$account}`)
+    const token = ctx.cookies.get(`VtexIdclientAutCookie_${account}`)
 
     const useHeaders = {
       'Content-Type': 'application/json',

--- a/node/resolvers/mutations/index.ts
+++ b/node/resolvers/mutations/index.ts
@@ -359,7 +359,7 @@ export const Mutation = {
       throw new GraphQLError('operation-not-permitted')
     }
 
-    const token = ctx.cookies.get(`VtexIdclientAutCookie`)
+    const token = ctx.cookies.get(`VtexIdclientAutCookie_$account}`)
 
     const useHeaders = {
       'Content-Type': 'application/json',

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -178,10 +178,10 @@
     "@types/mime" "^1"
     "@types/node" "*"
 
-"@vtex/api@6.45.19":
-  version "6.45.19"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.19.tgz#97b449850b517d6610e7123aa91caec2a29ae7b1"
-  integrity sha512-WUsAn1Oi+Z7Ih84DcRf4HQH85Mh+zO84L0ta7zuRyb13DoAEq2qMi0Mv6vZMd9BFWOCSD8AcTHVF/gZskwh9Yw==
+"@vtex/api@6.45.20":
+  version "6.45.20"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.20.tgz#c1090249a424fd700499de3fed0d80d99ff53332"
+  integrity sha512-O7RJWWr4PfvixNpc0GgQh85iKcv9j1IKkpApwJQSW/WzxoTgSrcjYHOVUmJ1GWWBmRV/qvB2VaV6Ow1QL3UOCQ==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -1522,7 +1522,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
#### What problem is this solving?

When a quote has a discount applied by a salesperson, the B2B Quotes won't apply the discount at checkout in the website domain, when using the same quotation to create the cart.

The auth token wasn't sent from quotes to checkout and orders.

#### How to test it?

1. Create a quote for any item with user A.
2. Open the quotes page with user B and change the price for the quote.
3. With user A, use the quote with discount and check the discount applied in the cart.

[Workspace](https://revendapjba.ferimport.com.br/b2b-quotes?workspace=ki849080)

#### Screenshots or example usage:

![quote](https://github.com/vtex-apps/b2b-quotes-graphql/assets/5332361/a444b84e-01ea-4cf7-8b0b-e54db71c02b9)

#### Describe alternatives you've considered, if any.

I would like to implement it as [b2b-organization](https://github.com/vtex-apps/b2b-organizations-graphql/blob/82457a3b294ed081d94e629d79e7a27443f569d3/node/clients/Oms.ts#L12), getting the auth token by context, but I will need to change too many things and create the typings.

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media3.giphy.com/media/YvyXAZk0DGfPuM2lb6/giphy.gif?cid=ecf05e47u7oh36n4n5bpx0x0rnf2o35lvjgmpjhr9wgbji2z&ep=v1_gifs_search&rid=giphy.gif)
