### PR TITLE
Add implementation for headless scenario

### DIFF
--- a/graphql/quote.graphql
+++ b/graphql/quote.graphql
@@ -4,6 +4,9 @@ input QuoteInput {
   subtotal: Float
   note: String
   sendToSalesRep: Boolean
+  organization: String
+  costCenter: String
+  role: String
 }
 
 input QuoteItemInput {
@@ -27,6 +30,9 @@ input QuoteUpdateInput {
   note: String
   decline: Boolean
   expirationDate: String
+  organization: String
+  costCenter: String
+  role: String
 }
 
 type Quotes {

--- a/manifest.json
+++ b/manifest.json
@@ -63,6 +63,9 @@
       "name": "send-message"
     },
     {
+      "name": "sphinx-is-admin"
+    },
+    {
       "name": "outbound-access",
       "attrs": {
         "host": "portal.vtexcommercestable.com.br",

--- a/node/clients/vtexId.ts
+++ b/node/clients/vtexId.ts
@@ -1,19 +1,25 @@
 import type { InstanceOptions, IOContext } from '@vtex/api'
-import { ExternalClient } from '@vtex/api'
+import { JanusClient } from '@vtex/api'
 
 interface AuthenticatedUser {
   user: string
 }
 
-export default class VtexId extends ExternalClient {
+export default class VtexId extends JanusClient {
   constructor(context: IOContext, options?: InstanceOptions) {
-    super('http://vtexid.vtex.com.br/api/', context, options)
+    super(context, {
+      ...options,
+      headers: {
+        ...options?.headers,
+        'x-vtex-user-agent': context.userAgent,
+      },
+    })
   }
 
   public async getAuthenticatedUser(
     authToken: string
   ): Promise<AuthenticatedUser> {
-    return this.http.get('vtexid/pub/authenticated/user/', {
+    return this.http.get('/api/vtexid/pub/authenticated/user/', {
       metric: 'authenticated-user-get',
       params: { authToken },
     })

--- a/node/metrics/createQuote.ts
+++ b/node/metrics/createQuote.ts
@@ -57,7 +57,7 @@ export class CreateQuoteMetric implements Metric {
 const buildQuoteMetric = (
   metricsParam: CreateQuoteMetricParam
 ): CreateQuoteMetric => {
-  const { namespaces } = metricsParam.sessionData
+  const { namespaces } = metricsParam.sessionData || {}
   const accountName = namespaces?.account?.accountName?.value
   const userEmail = namespaces?.profile?.email?.value
 

--- a/node/resolvers/directives/withSession.ts
+++ b/node/resolvers/directives/withSession.ts
@@ -10,16 +10,29 @@ export class WithSession extends SchemaDirectiveVisitor {
 
     field.resolve = async (root: any, args: any, context: any, info: any) => {
       const {
-        clients: { session },
+        clients: { session, vtexId },
         vtex: { sessionToken },
       } = context
 
-      context.vtex.sessionData = await session
-        .getSession(sessionToken as string, ['*'])
-        .then((currentSession: any) => {
-          return currentSession.sessionData
-        })
-        .catch(() => null)
+      const token = context.request.header?.vtexidclientauthcookie
+
+      if (sessionToken) {
+        context.vtex.sessionData = await session
+          .getSession(sessionToken as string, ['*'])
+          .then((currentSession: any) => {
+            return currentSession.sessionData
+          })
+          .catch(() => null)
+      } else if (token) {
+        const authenticatedUser = await vtexId.getAuthenticatedUser(token)
+
+        if (authenticatedUser?.userId) {
+          context.vtex.authenticatedUser = {
+            ...authenticatedUser,
+            token,
+          }
+        }
+      }
 
       return resolve(root, args, context, info)
     }


### PR DESCRIPTION
#### What problem is this solving?

These changes add support for headless implementations, it adds new optional fields on the schema to avoid the use of the store-front permissions in a mandotory way, those fields mock the ones fetched originally from the store-front permissions and also new validations are set in to identify when the requests are sent from a native environment or a headless one.

#### How to test it?

[Workspace](https://quote--bshgermany.myvtex.com/admin/graphql-ide)

#### Screenshots or example usage:

![image](https://github.com/vtex-apps/b2b-quotes-graphql/assets/81265466/76f43e3f-6e88-4fc4-9f6c-9de7fb3fd238)


#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![Cat](https://i.imgur.com/MqGBqZs.gif)
