### PR TITLE
feat: add token validation and set token in graphql clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add token validation in graphql operations and token to call storefront-permission and b2b-organization
+
 ## [2.4.1] - 2023-11-09
 
 ### Fixed

--- a/graphql/directives.graphql
+++ b/graphql/directives.graphql
@@ -3,3 +3,4 @@ directive @withPermissions on FIELD | FIELD_DEFINITION
 directive @withSegment on FIELD | FIELD_DEFINITION
 directive @checkAdminAccess on FIELD | FIELD_DEFINITION
 directive @auditAccess on FIELD | FIELD_DEFINITION
+directive @checkUserAccess on FIELD | FIELD_DEFINITION

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -30,7 +30,7 @@ type Mutation {
   useQuote(id: String, orderFormId: String): String
     @withPermissions
     @withSession
-  clearCart(orderFormId: String): String @auditAccess
+  clearCart(orderFormId: String): String @checkUserAccess
   saveAppSettings(input: AppSettingsInput!): AppSettings
     @cacheControl(scope: PRIVATE)
     @checkAdminAccess

--- a/manifest.json
+++ b/manifest.json
@@ -11,11 +11,10 @@
   },
   "dependencies": {
     "vtex.storefront-permissions": "1.x",
+    "vtex.b2b-organizations-graphql": "0.x",
     "vtex.orders-broadcast": "0.x"
   },
-  "registries": [
-    "smartcheckout"
-  ],
+  "registries": ["smartcheckout"],
   "policies": [
     {
       "name": "vbase-read-write"
@@ -48,7 +47,7 @@
       "name": "vtex.storefront-permissions:resolve-graphql"
     },
     {
-      "name": "vtex.graphql-server:resolve-graphql"
+      "name": "vtex.b2b-organizations-graphql:resolve-graphql"
     },
     {
       "name": "Get_User_By_Identifier"

--- a/node/clients/index.ts
+++ b/node/clients/index.ts
@@ -1,6 +1,8 @@
+import type { IOContext } from '@vtex/api'
 import { IOClients } from '@vtex/api'
 
 import RequestHub from '../utils/Hub'
+import Identity from '../utils/Identity'
 import { Scheduler } from '../utils/Scheduler'
 import Checkout from './checkout'
 import MailClient from './email'
@@ -9,9 +11,20 @@ import OrdersClient from './OrdersClient'
 import Organizations from './organizations'
 import StorefrontPermissions from './storefrontPermissions'
 import VtexId from './vtexId'
-import Identity from '../utils/Identity'
 
 // Extend the default IOClients implementation with our own custom clients.
+export const getTokenToHeader = (ctx: IOContext) => {
+  const token =
+    ctx.storeUserAuthToken ?? ctx.adminUserAuthToken ?? ctx.authToken
+
+  return {
+    VtexIdclientAutCookie: token,
+    cookie: `VtexIdclientAutCookie=${ctx.authToken}`,
+    sessionToken: ctx.sessionToken,
+    'x-vtex-session': ctx.sessionToken,
+  }
+}
+
 export class Clients extends IOClients {
   public get hub() {
     return this.getOrSet('hub', RequestHub)

--- a/node/clients/index.ts
+++ b/node/clients/index.ts
@@ -12,19 +12,19 @@ import Organizations from './organizations'
 import StorefrontPermissions from './storefrontPermissions'
 import VtexId from './vtexId'
 
-// Extend the default IOClients implementation with our own custom clients.
 export const getTokenToHeader = (ctx: IOContext) => {
   const token =
     ctx.storeUserAuthToken ?? ctx.adminUserAuthToken ?? ctx.authToken
 
   return {
     VtexIdclientAutCookie: token,
-    cookie: `VtexIdclientAutCookie=${ctx.authToken}`,
+    cookie: `VtexIdclientAutCookie=${token}`,
     sessionToken: ctx.sessionToken,
     'x-vtex-session': ctx.sessionToken,
   }
 }
 
+// Extend the default IOClients implementation with our own custom clients.
 export class Clients extends IOClients {
   public get hub() {
     return this.getOrSet('hub', RequestHub)

--- a/node/clients/index.ts
+++ b/node/clients/index.ts
@@ -16,11 +16,13 @@ export const getTokenToHeader = (ctx: IOContext) => {
   const token =
     ctx.storeUserAuthToken ?? ctx.adminUserAuthToken ?? ctx.authToken
 
+  const { sessionToken } = ctx
+
   return {
+    'x-vtex-credential': ctx.authToken,
     VtexIdclientAutCookie: token,
     cookie: `VtexIdclientAutCookie=${token}`,
-    sessionToken: ctx.sessionToken,
-    'x-vtex-session': ctx.sessionToken,
+    'x-vtex-session': sessionToken,
   }
 }
 

--- a/node/clients/organizations.ts
+++ b/node/clients/organizations.ts
@@ -1,38 +1,11 @@
 import type { InstanceOptions, IOContext } from '@vtex/api'
-import { AppClient, GraphQLClient } from '@vtex/api'
+import { AppGraphQLClient } from '@vtex/api'
 
-export default class Organizations extends AppClient {
-  protected graphql: GraphQLClient
+import { getTokenToHeader } from './index'
 
+export default class Organizations extends AppGraphQLClient {
   constructor(ctx: IOContext, options?: InstanceOptions) {
-    super('vtex.graphql-server@1.x', ctx, options)
-    this.graphql = new GraphQLClient(this.http)
-  }
-
-  public getOrganizationIDs = async (search: string): Promise<any> => {
-    const graphQLQuery = `query GetOrganizations($search: String!) {
-      getOrganizations(search: $search) {
-          data {
-              id
-          }
-        }
-      }`
-
-    return this.graphql.query(
-      {
-        extensions: {
-          persistedQuery: {
-            provider: 'vtex.b2b-organizations-graphql@0.x',
-            sender: 'vtex.b2b-quotes-graphql@1.x',
-          },
-        },
-        query: graphQLQuery,
-        variables: {
-          search,
-        },
-      },
-      { url: '/graphql' }
-    )
+    super('vtex.b2b-organizations-graphql@0.x', ctx, options)
   }
 
   public getOrganizationById = async (id: string): Promise<any> => {
@@ -43,47 +16,13 @@ export default class Organizations extends AppClient {
       }
       `
 
-    return this.graphql.query(
-      {
-        extensions: {
-          persistedQuery: {
-            provider: 'vtex.b2b-organizations-graphql@0.x',
-            sender: 'vtex.b2b-quotes-graphql@1.x',
-          },
-        },
-        query: graphQLQuery,
-        variables: {
-          id,
-        },
+    return this.query({
+      extensions: this.getPersistedQuery(),
+      query: graphQLQuery,
+      variables: {
+        id,
       },
-      { url: '/graphql' }
-    )
-  }
-
-  public getCostCenterIDs = async (search: string): Promise<any> => {
-    const graphQLQuery = `query GetCostCenters($search: String!) {
-      getCostCenters(search: $search) {
-          data {
-              id
-          }
-        }
-      }`
-
-    return this.graphql.query(
-      {
-        extensions: {
-          persistedQuery: {
-            provider: 'vtex.b2b-organizations-graphql@0.x',
-            sender: 'vtex.b2b-quotes-graphql@1.x',
-          },
-        },
-        query: graphQLQuery,
-        variables: {
-          search,
-        },
-      },
-      { url: '/graphql' }
-    )
+    })
   }
 
   public getCostCenterById = async (id: string): Promise<any> => {
@@ -94,20 +33,43 @@ export default class Organizations extends AppClient {
       }
       `
 
+    return this.query({
+      extensions: this.getPersistedQuery(),
+      query: graphQLQuery,
+      variables: {
+        id,
+      },
+    })
+  }
+
+  private getPersistedQuery = () => {
+    return {
+      persistedQuery: {
+        provider: 'vtex.b2b-organizations-graphql@0.x',
+        sender: 'vtex.b2b-quotes@0.x',
+      },
+    }
+  }
+
+  private query = async (param: {
+    query: string
+    variables: any
+    extensions: any
+  }): Promise<any> => {
+    const { query, variables, extensions } = param
+
     return this.graphql.query(
       {
-        extensions: {
-          persistedQuery: {
-            provider: 'vtex.b2b-organizations-graphql@0.x',
-            sender: 'vtex.b2b-quotes-graphql@1.x',
-          },
-        },
-        query: graphQLQuery,
-        variables: {
-          id,
-        },
+        extensions,
+        query,
+        variables,
       },
-      { url: '/graphql' }
+      {
+        headers: getTokenToHeader(this.context),
+        params: {
+          locale: this.context.locale,
+        },
+      }
     )
   }
 }

--- a/node/package.json
+++ b/node/package.json
@@ -8,7 +8,8 @@
     "jsonwebtoken": "^8.5.0",
     "ramda": "^0.25.0",
     "atob": "^2.1.2",
-    "axios": "0.27.2"
+    "axios": "0.27.2",
+    "@vtex/api": "6.46.0"
   },
   "devDependencies": {
     "@types/atob": "^2.1.2",
@@ -17,7 +18,6 @@
     "@types/jsonwebtoken": "^8.5.0",
     "@types/node": "^12.0.0",
     "@types/ramda": "types/npm-ramda#dist",
-    "@vtex/api": "6.45.20",
     "@vtex/prettier-config": "^0.3.1",
     "tslint": "^5.12.0",
     "tslint-config-prettier": "^1.18.0",

--- a/node/resolvers/directives.ts
+++ b/node/resolvers/directives.ts
@@ -1,8 +1,9 @@
-import { WithPermissions } from './directives/withPermissions'
-import { WithSession } from './directives/withSession'
-import { WithSegment } from './directives/withSegment'
-import { CheckAdminAccess } from './directives/checkAdminAccess'
 import { AuditAccess } from './directives/auditAccess'
+import { CheckAdminAccess } from './directives/checkAdminAccess'
+import { CheckUserAccess } from './directives/checkUserAccess'
+import { WithPermissions } from './directives/withPermissions'
+import { WithSegment } from './directives/withSegment'
+import { WithSession } from './directives/withSession'
 
 export const schemaDirectives = {
   withPermissions: WithPermissions as any,
@@ -10,4 +11,5 @@ export const schemaDirectives = {
   withSegment: WithSegment as any,
   checkAdminAccess: CheckAdminAccess as any,
   auditAccess: AuditAccess as any,
+  checkUserAccess: CheckUserAccess as any,
 }

--- a/node/resolvers/directives/checkUserAccess.ts
+++ b/node/resolvers/directives/checkUserAccess.ts
@@ -1,0 +1,74 @@
+import { AuthenticationError, ForbiddenError } from '@vtex/api'
+import type { GraphQLField } from 'graphql'
+import { defaultFieldResolver } from 'graphql'
+import { SchemaDirectiveVisitor } from 'graphql-tools'
+
+export class CheckUserAccess extends SchemaDirectiveVisitor {
+  public visitFieldDefinition(field: GraphQLField<any, any>) {
+    const { resolve = defaultFieldResolver } = field
+
+    field.resolve = async (
+      root: any,
+      args: any,
+      context: Context,
+      info: any
+    ) => {
+      const {
+        vtex: { adminUserAuthToken, storeUserAuthToken, logger },
+        clients: { identity, vtexId },
+      } = context
+
+      let token = adminUserAuthToken
+
+      const apiToken = context?.headers['vtex-api-apptoken'] as string
+      const appKey = context?.headers['vtex-api-appkey'] as string
+
+      if (apiToken?.length && appKey?.length) {
+        token = (
+          await identity.getToken({ appkey: appKey, apptoken: apiToken })
+        ).token
+        context.cookies.set('VtexIdclientAutCookie', token)
+        context.vtex.adminUserAuthToken = token
+      }
+
+      if (!token && !storeUserAuthToken) {
+        throw new AuthenticationError('No admin or store token was provided')
+      }
+
+      if (token) {
+        try {
+          await identity.validateToken(token)
+        } catch (err) {
+          logger.warn({
+            error: err,
+            message: 'CheckUserAccess: Invalid admin token',
+            token,
+          })
+          throw new ForbiddenError('Unauthorized Access')
+        }
+      } else if (storeUserAuthToken) {
+        let authUser = null
+
+        try {
+          authUser = await vtexId.getAuthenticatedUser(storeUserAuthToken)
+          if (!authUser?.user) {
+            authUser = null
+          }
+        } catch (err) {
+          logger.warn({
+            error: err,
+            message: 'CheckUserAccess: Invalid store user token',
+            token: storeUserAuthToken,
+          })
+          authUser = null
+        }
+
+        if (!authUser) {
+          throw new ForbiddenError('Unauthorized Access')
+        }
+      }
+
+      return resolve(root, args, context, info)
+    }
+  }
+}

--- a/node/resolvers/mutations/index.ts
+++ b/node/resolvers/mutations/index.ts
@@ -1,15 +1,15 @@
 import { indexBy, map, prop } from 'ramda'
 
 import {
-  checkConfig,
   checkAndCreateQuotesConfig,
+  checkConfig,
   defaultSettings,
 } from '../utils/checkConfig'
 import {
-  checkSession,
+  checkOperationsForUpdateQuote,
   checkPermissionsForUpdateQuote,
   checkQuoteStatus,
-  checkOperationsForUpdateQuote,
+  checkSession,
 } from '../utils/checkPermissions'
 import { isEmail } from '../../utils'
 import GraphQLError from '../../utils/GraphQLError'
@@ -18,8 +18,8 @@ import {
   APP_NAME,
   QUOTE_DATA_ENTITY,
   QUOTE_FIELDS,
-  SCHEMA_VERSION,
   routes,
+  SCHEMA_VERSION,
 } from '../../constants'
 import { sendCreateQuoteMetric } from '../../metrics/createQuote'
 import type { UseQuoteMetricsParams } from '../../metrics/useQuote'
@@ -346,7 +346,7 @@ export const Mutation = {
     const {
       clients: { masterdata, hub },
       vtex,
-      vtex: { account, logger },
+      vtex: { account, logger, storeUserAuthToken },
     } = ctx
 
     const { sessionData, storefrontPermissions } = vtex as any
@@ -359,11 +359,9 @@ export const Mutation = {
       throw new GraphQLError('operation-not-permitted')
     }
 
-    const token = ctx.cookies.get(`VtexIdclientAutCookie_${account}`)
-
     const useHeaders = {
       'Content-Type': 'application/json',
-      Cookie: `VtexIdclientAutCookie=${token};`,
+      Cookie: `VtexIdclientAutCookie=${storeUserAuthToken};`,
     }
 
     try {

--- a/node/utils/Identity.ts
+++ b/node/utils/Identity.ts
@@ -12,6 +12,16 @@ export default class Identity extends JanusClient {
   }
 
   public async validateToken(token: string): Promise<any> {
-    return this.http.post(`/api/vtexid/credential/validate`, { token })
+    return this.http.post('/api/vtexid/credential/validate', { token })
+  }
+
+  public async getToken({
+    appkey,
+    apptoken,
+  }: {
+    appkey: string
+    apptoken: string
+  }): Promise<any> {
+    return this.http.post('/api/vtexid/apptoken/login', { appkey, apptoken })
   }
 }

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -178,10 +178,10 @@
     "@types/mime" "^1"
     "@types/node" "*"
 
-"@vtex/api@6.45.20":
-  version "6.45.20"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.20.tgz#c1090249a424fd700499de3fed0d80d99ff53332"
-  integrity sha512-O7RJWWr4PfvixNpc0GgQh85iKcv9j1IKkpApwJQSW/WzxoTgSrcjYHOVUmJ1GWWBmRV/qvB2VaV6Ow1QL3UOCQ==
+"@vtex/api@6.46.0":
+  version "6.46.0"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.46.0.tgz#208d14b96cbc8fd5eb6bd18fbd0c8424886e6154"
+  integrity sha512-XAvJlD1FG1GynhPXiMcayunahFCL2r3ilO5MHAWKxYvB/ljyxi4+U+rVpweeaQGpxHfhKHdfPe7qNEEh2oa2lw==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -1522,7 +1522,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
What problem is this solving?

We found some apps that don't pass the token to call graphql queries or mutations. So we need a guarantee to have all integrations send the token, and we will block unauthenticated requests from the app provider.


[Workspace](https://security--b2bsuite.myvtex.com/)
