### PR TITLE
fix: use listUsersPaginated instead of deprecated listUsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Use listUsersPaginated internally instead of deprecated listUsers
+
 ## [2.5.3] - 2024-06-10
 
 ### Fixed

--- a/node/clients/index.ts
+++ b/node/clients/index.ts
@@ -13,16 +13,25 @@ import StorefrontPermissions from './storefrontPermissions'
 import VtexId from './vtexId'
 
 export const getTokenToHeader = (ctx: IOContext) => {
-  const token =
-    ctx.storeUserAuthToken ?? ctx.adminUserAuthToken ?? ctx.authToken
+  // provide authToken (app token) as an admin token as this is a call
+  // between b2b suite apps and no further token validation is needed
+  const adminToken = ctx.authToken
+  const userToken = ctx.storeUserAuthToken ?? null
+  const { sessionToken, account } = ctx
 
-  const { sessionToken } = ctx
+  let allCookies = `VtexIdclientAutCookie=${adminToken}`
+
+  if (userToken) {
+    allCookies += `; VtexIdclientAutCookie_${account}=${userToken}`
+  }
 
   return {
     'x-vtex-credential': ctx.authToken,
-    VtexIdclientAutCookie: token,
-    cookie: `VtexIdclientAutCookie=${token}`,
-    'x-vtex-session': sessionToken,
+    VtexIdclientAutCookie: adminToken,
+    cookie: allCookies,
+    ...(sessionToken && {
+      'x-vtex-session': sessionToken,
+    }), // The axios client http doesn't allow undefined headers
   }
 }
 

--- a/node/clients/storefrontPermissions.ts
+++ b/node/clients/storefrontPermissions.ts
@@ -41,17 +41,11 @@ export const QUERIES = {
       slug
     }
   }`,
-  listUsers: `query users($organizationId: ID, $costCenterId: ID, $roleId: ID) {
-    listUsers(organizationId: $organizationId, costCenterId: $costCenterId, roleId: $roleId) {
-      id
-      roleId
-      userId
-      clId
-      orgId
-      costId
-      name
-      email
-      canImpersonate
+  listUsersPaginated: `query users($organizationId: ID, $roleId: ID) {
+    listUsersPaginated(organizationId: $organizationId, roleId: $roleId) {
+      data {
+        email
+      }
     }
   }`,
 }
@@ -77,7 +71,7 @@ export default class StorefrontPermissions extends AppGraphQLClient {
     })
   }
 
-  public listUsers = async ({
+  public listUsersPaginated = async ({
     roleId,
     organizationId,
   }: {
@@ -86,7 +80,7 @@ export default class StorefrontPermissions extends AppGraphQLClient {
   }): Promise<any> => {
     return this.query({
       extensions: this.getPersistedQuery(),
-      query: QUERIES.listUsers,
+      query: QUERIES.listUsersPaginated,
       variables: {
         roleId,
         ...(organizationId && { organizationId }),

--- a/node/clients/storefrontPermissions.ts
+++ b/node/clients/storefrontPermissions.ts
@@ -41,7 +41,7 @@ export const QUERIES = {
       slug
     }
   }`,
-  listUsersPaginated: `query users($organizationId: ID, $roleId: ID) {
+  getOrgSalesAdminEmail: `query users($organizationId: ID, $roleId: ID) {
     listUsersPaginated(organizationId: $organizationId, roleId: $roleId) {
       data {
         email
@@ -71,7 +71,7 @@ export default class StorefrontPermissions extends AppGraphQLClient {
     })
   }
 
-  public listUsersPaginated = async ({
+  public getOrgSalesAdminEmail = async ({
     roleId,
     organizationId,
   }: {
@@ -80,7 +80,7 @@ export default class StorefrontPermissions extends AppGraphQLClient {
   }): Promise<any> => {
     return this.query({
       extensions: this.getPersistedQuery(),
-      query: QUERIES.listUsersPaginated,
+      query: QUERIES.getOrgSalesAdminEmail,
       variables: {
         roleId,
         ...(organizationId && { organizationId }),

--- a/node/package.json
+++ b/node/package.json
@@ -9,7 +9,7 @@
     "ramda": "^0.25.0",
     "atob": "^2.1.2",
     "axios": "0.27.2",
-    "@vtex/api": "6.46.0"
+    "@vtex/api": "6.47.0"
   },
   "devDependencies": {
     "@types/atob": "^2.1.2",

--- a/node/utils/message.ts
+++ b/node/utils/message.ts
@@ -12,32 +12,29 @@ interface QuoteUpdate {
 // As this is currently used only to get the sales-admin users to
 // send an email notification when a quote is created, we only get
 // the first page of users (25) and return them.
-// If there is a new use case where we need to get all users,
-// we need to implement pagination properly.
-const getUsers = async (
+const getOrgSalesAdminEmail = async (
   storefrontPermissions: StorefrontPermissions,
-  roleSlug: string,
   organizationId?: string
 ) => {
   const {
     data: { listRoles },
   }: any = await storefrontPermissions.listRoles()
 
-  const role = listRoles.find((r: any) => r.slug === roleSlug)
+  const role = listRoles.find((r: any) => r.slug === 'sales-admin')
 
   if (!role) {
     return []
   }
 
   const {
-    data: { listUsersPaginated },
-  }: any = await storefrontPermissions.listUsersPaginated({
+    data: { getOrgSalesAdminEmail },
+  }: any = await storefrontPermissions.getOrgSalesAdminEmail({
     roleId: role.id,
     ...(organizationId && { organizationId }),
   })
 
-  // we only return the first page of users (25)
-  return listUsersPaginated.data
+  // we only return the first page of sales-admin users (25)
+  return getOrgSalesAdminEmail.data
 }
 
 const getOrgAndCostCenterNames = async (
@@ -165,13 +162,13 @@ const message = (ctx: Context | EventBroadcastContext) => {
     let users = []
 
     try {
-      users = (await getUsers(storefrontPermissions, 'sales-admin', organization)).map(
+      users = (await getOrgSalesAdminEmail(storefrontPermissions, organization)).map(
         (user: any) => user.email
       )
     } catch (error) {
       logger.error({
         error,
-        message: 'quoteCreatedMessage-getUsersError',
+        message: 'quoteCreatedMessage-getOrgSalesAdminEmailError',
       })
     }
 

--- a/node/utils/message.ts
+++ b/node/utils/message.ts
@@ -9,6 +9,11 @@ interface QuoteUpdate {
   note: string
 }
 
+// As this is currently used only to get the sales-admin users to
+// send an email notification when a quote is created, we only get
+// the first page of users (25) and return them.
+// If there is a new use case where we need to get all users,
+// we need to implement pagination properly.
 const getUsers = async (
   storefrontPermissions: StorefrontPermissions,
   roleSlug: string,
@@ -25,13 +30,14 @@ const getUsers = async (
   }
 
   const {
-    data: { listUsers },
-  }: any = await storefrontPermissions.listUsers({
+    data: { listUsersPaginated },
+  }: any = await storefrontPermissions.listUsersPaginated({
     roleId: role.id,
     ...(organizationId && { organizationId }),
   })
 
-  return listUsers
+  // we only return the first page of users (25)
+  return listUsersPaginated.data
 }
 
 const getOrgAndCostCenterNames = async (
@@ -159,7 +165,7 @@ const message = (ctx: Context | EventBroadcastContext) => {
     let users = []
 
     try {
-      users = (await getUsers(storefrontPermissions, 'sales-admin')).map(
+      users = (await getUsers(storefrontPermissions, 'sales-admin', organization)).map(
         (user: any) => user.email
       )
     } catch (error) {

--- a/node/utils/message.ts
+++ b/node/utils/message.ts
@@ -27,14 +27,14 @@ const getOrgSalesAdminEmail = async (
   }
 
   const {
-    data: { getOrgSalesAdminEmail },
+    data: { getOrgSalesAdminEmailResult },
   }: any = await storefrontPermissions.getOrgSalesAdminEmail({
     roleId: role.id,
     ...(organizationId && { organizationId }),
   })
 
   // we only return the first page of sales-admin users (25)
-  return getOrgSalesAdminEmail.data
+  return getOrgSalesAdminEmailResult.data
 }
 
 const getOrgAndCostCenterNames = async (
@@ -162,9 +162,9 @@ const message = (ctx: Context | EventBroadcastContext) => {
     let users = []
 
     try {
-      users = (await getOrgSalesAdminEmail(storefrontPermissions, organization)).map(
-        (user: any) => user.email
-      )
+      users = (
+        await getOrgSalesAdminEmail(storefrontPermissions, organization)
+      ).map((user: any) => user.email)
     } catch (error) {
       logger.error({
         error,

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -178,10 +178,10 @@
     "@types/mime" "^1"
     "@types/node" "*"
 
-"@vtex/api@6.46.0":
-  version "6.46.0"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.46.0.tgz#208d14b96cbc8fd5eb6bd18fbd0c8424886e6154"
-  integrity sha512-XAvJlD1FG1GynhPXiMcayunahFCL2r3ilO5MHAWKxYvB/ljyxi4+U+rVpweeaQGpxHfhKHdfPe7qNEEh2oa2lw==
+"@vtex/api@6.47.0":
+  version "6.47.0"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.47.0.tgz#6910455d593d8bb76f1f4f2b7660023853fda35e"
+  integrity sha512-t9gt7Q89EMbSj3rLhho+49Fv+/lQgiy8EPVRgtmmXFp1J4v8hIAZF7GPjCPie111KVs4eG0gfZFpmhA5dafKNA==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -1522,7 +1522,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
#### What problem is this solving?

Use listUsersPaginated instead of deprecated listUsers.

This includes the following changes:
* Fix tokens provided on requests to storefront-permissions (provide app auth token)
* Refactor `getUsers` to `getOrgSalesAdminEmail`.
* Provide the organization id when querying users in order to send e-mail only to sales-admin users of that organization.
* Query only the email on listUsersPaginated as this is the only information currently used.
* Query only the first page (25 users) as it is very unlikely we will have 25+ sales-admin for a single organization (this helps to keep the code simple).

Note: This PR does not implement pagination for the listUsersPaginated query, if this is needed in the future, proper pagination must be implemented.