### PR TITLE
add: get quote enabled for user query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Add getQuoteEnabledForUser query to be used by the b2b-quotes app
+
 ## [2.5.4] - 2024-08-20
 
 ### Fixed

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -1,5 +1,7 @@
 type Query {
   getAppSettings: AppSettings @cacheControl(scope: PRIVATE, maxAge: SHORT)
+  getQuoteEnabledForUser(email: String!): Boolean
+    @cacheControl(scope: PRIVATE, maxAge: SHORT)
   getQuote(id: String): Quote
     @withPermissions
     @withSession

--- a/node/constants.ts
+++ b/node/constants.ts
@@ -1,6 +1,8 @@
 export const APP_NAME = 'b2b-quotes-graphql'
 export const SCHEMA_VERSION = 'v1.3'
 export const QUOTE_DATA_ENTITY = 'quotes'
+export const B2B_USER_SCHEMA_VERSION = 'v0.1.2'
+export const B2B_USER_DATA_ENTITY = 'b2b_users'
 export const CRON_EXPRESSION = '0 */12 * * *'
 
 export const QUOTE_FIELDS = [


### PR DESCRIPTION
#### What problem is this solving?

Currently, frontend (`b2b-quotes`) calls the `getUserByEmail` API from `b2b-organizations-graphql` app to check if the user is part of a buyer org and, if it is, show the "My Quotes" button on "My Account" page.
The `getUserByEmail` API returns much more stuff than necessary. Instead, now we have a much simpler query with restricted info on the `b2b-quotes-graphql` app, which should be faster, less error prone, and will also simplify overall B2B Suite code.

Related PR on `b2b-quotes` which will use this new API: https://github.com/vtex-apps/b2b-quotes/pull/62
