### PR TITLE
fix: set viewedByCustomer value correctly on quote creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Set viewedByCustomer value corectly on quote creation
+
 ## [2.5.4] - 2024-08-20
 
 ### Fixed

--- a/node/resolvers/mutations/index.ts
+++ b/node/resolvers/mutations/index.ts
@@ -127,7 +127,7 @@ export const Mutation = {
       status,
       subtotal,
       updateHistory,
-      viewedByCustomer: sendToSalesRep,
+      viewedByCustomer: !!sendToSalesRep,
       viewedBySales: !sendToSalesRep,
       salesChannel,
     }

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1522,7 +1522,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
#### What problem is this solving?

The `sendToSalesRep` input was being used to set the value for `viewedByCustomer` on quote creation, but if `sendToSalesRep` was not provided, `viewedByCustomer` would end up with a `null` value, causing an error on quote expiration while writing to master data.

This fix will set `viewedByCustomer` value to `false` if `sendToSalesRep` is not provided on quote creation.
