### PR TITLE
fix: Set viewedByCustomer is false, where is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Set viewedByCustomer value False when value is null
+
 ## [2.6.2] - 2024-10-02
 
 ### Added

--- a/node/resolvers/mutations/index.ts
+++ b/node/resolvers/mutations/index.ts
@@ -290,8 +290,8 @@ export const Mutation = {
         status,
         subtotal: subtotal ?? existingQuote.subtotal,
         updateHistory,
-        viewedByCustomer: decline || isCustomer,
-        viewedBySales: decline || isSales,
+        viewedByCustomer: !!(decline || isCustomer),
+        viewedBySales: !!(decline || isSales),
       }
 
       const data = await masterdata

--- a/node/utils/Queue.ts
+++ b/node/utils/Queue.ts
@@ -15,7 +15,7 @@ const processItem = ({ ctx, item }: { ctx: Context; item: Quote }) => {
   }
 
   if (item.viewedByCustomer === null) {
-    item.viewedByCustomer = false;
+    item.viewedByCustomer = false
   }
 
   const status = 'expired'

--- a/node/utils/Queue.ts
+++ b/node/utils/Queue.ts
@@ -14,6 +14,10 @@ const processItem = ({ ctx, item }: { ctx: Context; item: Quote }) => {
     return
   }
 
+  if (item.viewedByCustomer === null) {
+    item.viewedByCustomer = false;
+  }
+
   const status = 'expired'
   const now = new Date()
   const nowISO = now.toISOString()


### PR DESCRIPTION
This PR ensures that the `viewedByCustomer` property is always a boolean (true or false). This change prevents potential issues caused by null or undefined values.

Changes
Updated the assignment of `viewedByCustomer` to use double negation (!!) to ensure it is always a boolean.