### PR TITLE
 [Seller Quotes] Add new markeplace splitting quotes on graphql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Add new input quotesManagedBy on appSettings to handle splitting marketplace
+
 ## [2.6.4] - 2024-10-31
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,36 +8,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Add new input quotesManagedBy on appSettings to handle splitting quotes
+
+- Add field quotesManagedBy on appSettings to handle splitting quotes
 
 ## [2.6.4] - 2024-10-31
 
 ### Fixed
+
 - Only update Status, LastUpdate and UpdateHistory, in expired quotes
 
 ## [2.6.3] - 2024-10-30
 
 ### Fixed
+
 - Set viewedByCustomer value False when value is null
 
 ## [2.6.2] - 2024-10-02
 
 ### Added
+
 - Add audit access metrics to all graphql APIs
 
 ## [2.6.1] - 2024-09-09
 
 ### Fixed
+
 - Set viewedByCustomer value corectly on quote creation
 
 ## [2.6.0] - 2024-09-04
 
 ### Added
+
 - Add getQuoteEnabledForUser query to be used by the b2b-quotes app
 
 ## [2.5.4] - 2024-08-20
 
 ### Fixed
+
 - Use listUsersPaginated internally instead of deprecated listUsers
 
 ## [2.5.3] - 2024-06-10
@@ -79,15 +86,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.3.1] - 2023-09-13
 
 ### Fixed
+
 - Use the account to get the token in the header and send it to clear the cart and order
 
 ## [2.3.0] - 2023-08-14
 
 ### Added
+
 - Send metrics to Analytics (Create Quote and Send Message events)
-- Send use quote metrics to Analytics 
-  
+- Send use quote metrics to Analytics
+
 ### Removed
+
 - [ENGINEERS-1247] - Disable cypress tests in PR level
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Add new input quotesManagedBy on appSettings to handle splitting marketplace
+- Add new input quotesManagedBy on appSettings to handle splitting quotes
 
 ## [2.6.4] - 2024-10-31
 

--- a/graphql/appSettings.graphql
+++ b/graphql/appSettings.graphql
@@ -3,7 +3,13 @@ type AppSettings {
 }
 type AdminSetup {
   cartLifeSpan: Int
+  quotesManagedBy: QuotesManagedBy!
 }
 input AppSettingsInput {
   cartLifeSpan: Int
+  quotesManagedBy: QuotesManagedBy
+}
+enum QuotesManagedBy {
+  MARKETPLACE
+  SELLER
 }

--- a/node/resolvers/mutations/index.ts
+++ b/node/resolvers/mutations/index.ts
@@ -497,7 +497,9 @@ export const Mutation = {
   },
   saveAppSettings: async (
     _: void,
-    { input: { cartLifeSpan, quotesManagedBy = 'MARKETPLACE' } }: { input: { cartLifeSpan: number , quotesManagedBy: string} },
+    {
+      input: { cartLifeSpan, quotesManagedBy = 'MARKETPLACE' },
+    }: { input: { cartLifeSpan: number; quotesManagedBy: string } },
     ctx: Context
   ) => {
     const {

--- a/node/resolvers/mutations/index.ts
+++ b/node/resolvers/mutations/index.ts
@@ -1,6 +1,19 @@
 import { indexBy, map, prop } from 'ramda'
 
 import {
+  APP_NAME,
+  QUOTE_DATA_ENTITY,
+  QUOTE_FIELDS,
+  routes,
+  SCHEMA_VERSION,
+} from '../../constants'
+import { sendCreateQuoteMetric } from '../../metrics/createQuote'
+import type { UseQuoteMetricsParams } from '../../metrics/useQuote'
+import { sendUseQuoteMetric } from '../../metrics/useQuote'
+import { isEmail } from '../../utils'
+import GraphQLError from '../../utils/GraphQLError'
+import message from '../../utils/message'
+import {
   checkAndCreateQuotesConfig,
   checkConfig,
   defaultSettings,
@@ -11,19 +24,6 @@ import {
   checkQuoteStatus,
   checkSession,
 } from '../utils/checkPermissions'
-import { isEmail } from '../../utils'
-import GraphQLError from '../../utils/GraphQLError'
-import message from '../../utils/message'
-import {
-  APP_NAME,
-  QUOTE_DATA_ENTITY,
-  QUOTE_FIELDS,
-  routes,
-  SCHEMA_VERSION,
-} from '../../constants'
-import { sendCreateQuoteMetric } from '../../metrics/createQuote'
-import type { UseQuoteMetricsParams } from '../../metrics/useQuote'
-import { sendUseQuoteMetric } from '../../metrics/useQuote'
 
 export const Mutation = {
   clearCart: async (_: any, params: any, ctx: Context) => {
@@ -497,7 +497,7 @@ export const Mutation = {
   },
   saveAppSettings: async (
     _: void,
-    { input: { cartLifeSpan } }: { input: { cartLifeSpan: number } },
+    { input: { cartLifeSpan, quotesManagedBy = 'MARKETPLACE' } }: { input: { cartLifeSpan: number , quotesManagedBy: string} },
     ctx: Context
   ) => {
     const {
@@ -533,6 +533,7 @@ export const Mutation = {
       adminSetup: {
         ...settings.adminSetup,
         cartLifeSpan,
+        quotesManagedBy,
       },
     }
 

--- a/node/resolvers/queries/index.ts
+++ b/node/resolvers/queries/index.ts
@@ -334,10 +334,10 @@ export const Query = {
       return null
     }
 
-    if(settings && !settings?.adminSetup.quotesManagedBy){
+    if (settings && !settings?.adminSetup.quotesManagedBy) {
       settings.adminSetup.quotesManagedBy = 'MARKETPLACE'
     }
-    
+
     return settings
   },
 }

--- a/node/resolvers/queries/index.ts
+++ b/node/resolvers/queries/index.ts
@@ -1,5 +1,3 @@
-import { checkConfig } from '../utils/checkConfig'
-import GraphQLError from '../../utils/GraphQLError'
 import {
   APP_NAME,
   B2B_USER_DATA_ENTITY,
@@ -8,6 +6,8 @@ import {
   QUOTE_FIELDS,
   SCHEMA_VERSION,
 } from '../../constants'
+import GraphQLError from '../../utils/GraphQLError'
+import { checkConfig } from '../utils/checkConfig'
 
 // This function checks if given email is an user part of a buyer org.
 export const isUserPartOfBuyerOrg = async (email: string, ctx: Context) => {
@@ -334,6 +334,10 @@ export const Query = {
       return null
     }
 
+    if(settings && !settings?.adminSetup.quotesManagedBy){
+      settings.adminSetup.quotesManagedBy = 'MARKETPLACE'
+    }
+    
     return settings
   },
 }

--- a/node/resolvers/utils/checkConfig.ts
+++ b/node/resolvers/utils/checkConfig.ts
@@ -13,6 +13,7 @@ export const defaultSettings: Settings = {
   adminSetup: {
     allowManualPrice: false,
     cartLifeSpan: 30,
+    quotesManagedBy: 'MARKETPLACE',
     hasCron: false,
   },
   schemaVersion: '',
@@ -345,7 +346,10 @@ export const checkConfig = async (ctx: Context) => {
     return null
   }
 
-  if (!settings?.adminSetup?.cartLifeSpan) {
+  if (
+    !settings?.adminSetup?.cartLifeSpan &&
+    !settings?.adminSetup?.quotesManagedBy
+  ) {
     settings = defaultSettings
     changed = true
   }

--- a/node/typings.d.ts
+++ b/node/typings.d.ts
@@ -106,6 +106,7 @@ interface Settings {
     hasCron?: boolean
     cronExpression?: string
     cronWorkspace?: string
+    quotesManagedBy?: string
   }
   schemaVersion: string
   templateHash: string | null


### PR DESCRIPTION
### What problem is this solving?
This solves the problem of managing feature control for the splitting quote functionality in the application. By adding the new marketplace configuration to the AppSettings, it provides a centralized and efficient way to enable or disable the splitting quote feature as needed, ensuring flexibility and ease of configuration.

### How to test it?
 - Log at the Application Level: Add logs within the application to verify the AppSettings values returned, ensuring the new marketplace configuration is properly set.
 - GraphQL Playground: Use the GraphQL Playground at <YOUR_STORE>.myvtex.com/admin/graphql-ide to manually query the settings and confirm the splitting quote feature is correctly configured.

#### Screenshots or example usage:

![image](https://github.com/user-attachments/assets/2e5c0901-b6b5-4c5f-8df0-a3512699c75c)

#### Describe alternatives you've considered, if any.

 [Task link](https://app.clickup.com/t/868awnf1b)

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://giphy.com/gifs/tv2norge-dance-celebration-birthday-duNowzaVje6Di3hnOu)
