### PR TITLE
[Seller Quotes] feat: quote new fields and create children quote for …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add fields creatorName, sellerName and childrenQuantity on quote entity
+- Saving masterdata schema hash in settings to update when it changes
+- Create a new quote to marketplace responsibility for remaining items when splitting a quote
+- Create a new query to check sellers quotes on frontend
+
+### Changed
+
+- Handle parent quote status and subtotal when updating splitted quotes
+- Get all children quotes ordered by lastUpdate DESC once on getChildrenQuotes
+
 ## [2.8.0] - 2025-01-13
 
 ### Added

--- a/graphql/quote.graphql
+++ b/graphql/quote.graphql
@@ -44,6 +44,7 @@ type Quote {
   id: String
   referenceName: String
   creatorEmail: String
+  creatorName: String
   creatorRole: String
   creationDate: String
   expirationDate: String
@@ -60,8 +61,10 @@ type Quote {
   viewedByCustomer: Boolean
   salesChannel: String
   seller: String
+  sellerName: String
   parentQuote: String
   hasChildren: Boolean
+  childrenQuantity: Int
 }
 
 type QuoteUpdate {
@@ -84,4 +87,9 @@ type QuoteItem {
   quantity: Int
   sellingPrice: Float
   seller: String
+}
+
+type Seller {
+  id: String
+  name: String
 }

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -28,11 +28,15 @@ type Query {
     @cacheControl(scope: PRIVATE, maxAge: SHORT)
   getChildrenQuotes(
     id: String
-    page: Int = 1
-    pageSize: Int = 25
     sortOrder: String = "DESC"
     sortedBy: String = "lastUpdate"
-  ): Quotes
+  ): [Quote]
+    @auditAccess
+    @withPermissions
+    @withSession
+    @withSegment
+    @cacheControl(scope: PRIVATE, maxAge: SHORT)
+  checkSellerQuotes(sellers: [String!]!): [Seller!]!
     @auditAccess
     @withPermissions
     @withSession

--- a/manifest.json
+++ b/manifest.json
@@ -14,9 +14,7 @@
     "vtex.b2b-organizations-graphql": "0.x",
     "vtex.orders-broadcast": "0.x"
   },
-  "registries": [
-    "smartcheckout"
-  ],
+  "registries": ["smartcheckout"],
   "policies": [
     {
       "name": "vbase-read-write"

--- a/node/clients/SellerClient.ts
+++ b/node/clients/SellerClient.ts
@@ -1,0 +1,18 @@
+import type { IOContext, InstanceOptions } from '@vtex/api'
+import { JanusClient } from '@vtex/api'
+
+export default class SellerClient extends JanusClient {
+  constructor(context: IOContext, options?: InstanceOptions) {
+    super(context, {
+      ...options,
+      headers: {
+        ...options?.headers,
+        VtexIdclientAutcookie: context.authToken,
+      },
+    })
+  }
+
+  public async getSeller(sellerId: string) {
+    return this.http.get<Seller>(`/api/seller-register/pvt/sellers/${sellerId}`)
+  }
+}

--- a/node/clients/index.ts
+++ b/node/clients/index.ts
@@ -14,6 +14,7 @@ import Organizations from './organizations'
 import StorefrontPermissions from './storefrontPermissions'
 import VtexId from './vtexId'
 import SellerQuotesClient from './SellerQuotesClient'
+import SellerClient from './SellerClient'
 
 export const getTokenToHeader = (ctx: IOContext) => {
   // provide authToken (app token) as an admin token as this is a call
@@ -90,5 +91,9 @@ export class Clients extends IOClients {
 
   public get sellerQuotes() {
     return this.getOrSet('sellerQuotes', SellerQuotesClient)
+  }
+
+  public get seller() {
+    return this.getOrSet('seller', SellerClient)
   }
 }

--- a/node/constants.ts
+++ b/node/constants.ts
@@ -9,6 +9,7 @@ export const QUOTE_FIELDS = [
   'id',
   'referenceName',
   'creatorEmail',
+  'creatorName',
   'creatorRole',
   'creationDate',
   'expirationDate',
@@ -23,8 +24,10 @@ export const QUOTE_FIELDS = [
   'viewedByCustomer',
   'salesChannel',
   'seller',
+  'sellerName',
   'parentQuote',
   'hasChildren',
+  'childrenQuantity',
 ]
 
 export const routes = {
@@ -87,6 +90,10 @@ export const schema = {
       title: 'Creator Email',
       type: 'string',
     },
+    creatorName: {
+      title: 'Creator Name',
+      type: ['null', 'string'],
+    },
     creatorRole: {
       title: 'Creator Role',
       type: 'string',
@@ -141,6 +148,10 @@ export const schema = {
       title: 'Seller',
       type: ['null', 'string'],
     },
+    sellerName: {
+      title: 'Seller Name',
+      type: ['null', 'string'],
+    },
     parentQuote: {
       title: 'Parent quote',
       type: ['null', 'string'],
@@ -149,11 +160,16 @@ export const schema = {
       title: 'Has children',
       type: ['null', 'boolean'],
     },
+    childrenQuantity: {
+      title: 'Children Quantity',
+      type: ['null', 'number'],
+    },
   },
   'v-cache': false,
   'v-default-fields': [
     'referenceName',
     'creatorEmail',
+    'creatorName',
     'creationDate',
     'expirationDate',
     'lastUpdate',
@@ -161,12 +177,15 @@ export const schema = {
     'subtotal',
     'status',
     'seller',
+    'sellerName',
     'parentQuote',
     'hasChildren',
+    'childrenQuantity',
   ],
   'v-immediate-indexing': true,
   'v-indexed': [
     'creatorEmail',
+    'creatorName',
     'creationDate',
     'expirationDate',
     'lastUpdate',
@@ -176,6 +195,7 @@ export const schema = {
     'costCenter',
     'salesChannel',
     'seller',
+    'sellerName',
     'parentQuote',
     'hasChildren',
   ],

--- a/node/middlewares/order.ts
+++ b/node/middlewares/order.ts
@@ -1,4 +1,5 @@
 import { QUOTE_DATA_ENTITY, QUOTE_FIELDS, SCHEMA_VERSION } from '../constants'
+import SellerQuotesController from '../resolvers/utils/sellerQuotesController'
 import { isEmail, NO_REPLY_EMAIL } from '../utils'
 import message from '../utils/message'
 
@@ -47,58 +48,22 @@ export async function orderHandler(
           id: quoteId,
         })) as Quote
 
-        const quote = {
-          ...item,
-          status: 'placed',
-          updateHistory: [
-            ...item.updateHistory,
-            {
-              date: new Date().toISOString(),
-              email: NO_REPLY_EMAIL,
-              note: `Order ID: ${body.orderId}`,
-              role: 'order-notification-system',
-              status: 'placed',
-            },
-          ],
+        const quotes: Quote[] = []
+
+        quotes.push(item)
+
+        if (item.hasChildren) {
+          const sellerQuotesController = new SellerQuotesController(ctx)
+          const childrenQuotes = await sellerQuotesController.getAllChildrenQuotes(
+            quoteId
+          )
+
+          quotes.push(...childrenQuotes)
         }
 
-        await masterdata
-          .updateEntireDocument({
-            dataEntity: QUOTE_DATA_ENTITY,
-            fields: quote,
-            id: quoteId,
-            schema: SCHEMA_VERSION,
-          })
-          .then((res: any) => res)
-
-        const users = quote.updateHistory.map((anUpdate) => anUpdate.email)
-
-        const uniqueUsers = [
-          ...new Set(
-            users.filter((userEmail: string) => isEmail.test(userEmail))
-          ),
-        ]
-
-        message(ctx)
-          .quoteUpdated({
-            costCenter: quote.costCenter,
-            id: quoteId,
-            lastUpdate: {
-              email: 'order-notification-system',
-              note: `Order ID: ${body.orderId}`,
-              status: 'PLACED',
-            },
-            name: quote.referenceName,
-            orderId: body.orderId,
-            organization: quote.organization,
-            templateName: 'quote-order-placed',
-            users: uniqueUsers,
-          })
-          .then(() => {
-            logger.info({
-              message: `[Quote placed] E-mail sent ${uniqueUsers.join(', ')}`,
-            })
-          })
+        await Promise.all(
+          quotes.map((quote) => processQuote(ctx, order, quote))
+        )
       }
     }
   } catch (error) {
@@ -111,4 +76,69 @@ export async function orderHandler(
   }
 
   return next()
+}
+
+async function processQuote(
+  ctx: EventBroadcastContext,
+  order: Order,
+  quote: Quote
+) {
+  const { orderId } = order
+
+  const mustAddUpdateHistory =
+    !quote.seller ||
+    (quote.seller && order.items.some((item) => item.seller === quote.seller))
+
+  if (mustAddUpdateHistory) {
+    quote.updateHistory.push({
+      date: new Date().toISOString(),
+      email: NO_REPLY_EMAIL,
+      note: `Order ID: ${orderId}`,
+      role: 'order-notification-system',
+      status: 'placed',
+    })
+  }
+
+  const quoteUpdated = {
+    ...quote,
+    status: 'placed',
+    updateHistory: quote.updateHistory,
+  }
+
+  await ctx.clients.masterdata.updateEntireDocument({
+    dataEntity: QUOTE_DATA_ENTITY,
+    fields: quoteUpdated,
+    id: quote.id,
+    schema: SCHEMA_VERSION,
+  })
+
+  // just users from single or children quotes need to be notified
+  if (quote.hasChildren) return
+
+  const users = quoteUpdated.updateHistory.map((anUpdate) => anUpdate.email)
+
+  const uniqueUsers = [
+    ...new Set(users.filter((userEmail: string) => isEmail.test(userEmail))),
+  ]
+
+  message(ctx)
+    .quoteUpdated({
+      costCenter: quoteUpdated.costCenter,
+      id: quote.id,
+      lastUpdate: {
+        email: 'order-notification-system',
+        note: `Order ID: ${orderId}`,
+        status: 'PLACED',
+      },
+      name: quoteUpdated.referenceName,
+      orderId,
+      organization: quoteUpdated.organization,
+      templateName: 'quote-order-placed',
+      users: uniqueUsers,
+    })
+    .then(() => {
+      ctx.vtex.logger.info({
+        message: `[Quote placed] E-mail sent ${uniqueUsers.join(', ')}`,
+      })
+    })
 }

--- a/node/resolvers/fieldResolvers.ts
+++ b/node/resolvers/fieldResolvers.ts
@@ -1,7 +1,7 @@
 export const organizationName = async (
   { organization }: { organization: string },
   _: any,
-  ctx: Context
+  ctx: Context | EventBroadcastContext
 ) => {
   const {
     clients: { organizations },
@@ -25,7 +25,7 @@ export const organizationName = async (
 export const costCenterName = async (
   { costCenter }: { costCenter: string },
   _: any,
-  ctx: Context
+  ctx: Context | EventBroadcastContext
 ) => {
   const {
     clients: { organizations },

--- a/node/resolvers/mutations/index.ts
+++ b/node/resolvers/mutations/index.ts
@@ -29,6 +29,7 @@ import {
   createQuoteObject,
   splitItemsBySeller,
 } from '../utils/quotes'
+import SellerQuotesController from '../utils/sellerQuotesController'
 
 export const Mutation = {
   clearCart: async (_: any, params: any, ctx: Context) => {
@@ -99,16 +100,27 @@ export const Mutation = {
         })
       }
 
-      const hasSellerQuotes = Object.keys(quoteBySeller).length
+      const sellerQuotesQuantity = Object.keys(quoteBySeller).length
 
-      const parentQuoteItems = hasSellerQuotes
-        ? items.filter(
-            (item) =>
-              !Object.values(quoteBySeller).some((quote) =>
-                quote.items.some(createItemComparator(item))
-              )
+      const remainingItems = items.filter(
+        (item) =>
+          !Object.values(quoteBySeller).some((quote) =>
+            quote.items.some(createItemComparator(item))
           )
-        : items
+      )
+
+      const isOnlyOneQuote =
+        !sellerQuotesQuantity ||
+        (sellerQuotesQuantity === 1 && !remainingItems.length)
+
+      const [firstSellerQuote] = Object.values(quoteBySeller)
+
+      const parentQuoteItems =
+        isOnlyOneQuote && firstSellerQuote
+          ? firstSellerQuote.items
+          : sellerQuotesQuantity
+          ? remainingItems
+          : items
 
       const quoteCommonFields = {
         sessionData,
@@ -118,23 +130,18 @@ export const Mutation = {
         referenceName,
         note,
         sendToSalesRep,
+        sellerQuotesQuantity,
       }
 
-      // We believe that parent quote should contain the overall subtotal.
-      // If for some reason it is necessary to subtract the subtotal from
-      // sellers quotes, we can use the adjustedSubtotal below, assigning
-      // it to subtotal in createQuoteObject -> `subtotal: adjustedSubtotal`
-      //
-      // const adjustedSubtotal = hasSellerQuotes
-      //   ? Object.values(quoteBySeller).reduce(
-      //       (acc, quote) => acc - quote.subtotal,
-      //       subtotal
-      //     )
-      //   : subtotal
       const parentQuote = createQuoteObject({
         ...quoteCommonFields,
         items: parentQuoteItems,
         subtotal,
+        ...(isOnlyOneQuote &&
+          firstSellerQuote && {
+            seller: firstSellerQuote.seller,
+            sellerName: firstSellerQuote.sellerName,
+          }),
       })
 
       const { DocumentId: parentQuoteId } = await masterdata.createDocument({
@@ -143,13 +150,50 @@ export const Mutation = {
         schema: SCHEMA_VERSION,
       })
 
-      if (hasSellerQuotes) {
+      if (isOnlyOneQuote) {
+        if (firstSellerQuote) {
+          await ctx.clients.sellerQuotes.notifyNewQuote(
+            firstSellerQuote.seller,
+            parentQuoteId,
+            parentQuote.creationDate
+          )
+        }
+      } else {
+        const childrenQuoteIds: string[] = []
+
+        if (parentQuoteItems.length) {
+          const marketplaceSubtotal = parentQuoteItems.reduce(
+            (acc, item) => acc + item.sellingPrice * item.quantity,
+            0
+          )
+
+          const marketplaceSeller = await ctx.clients.seller.getSeller('1')
+
+          const marketplaceQuote = createQuoteObject({
+            ...quoteCommonFields,
+            items: parentQuoteItems,
+            subtotal: marketplaceSubtotal,
+            seller: '1',
+            sellerName: marketplaceSeller?.name ?? ctx.vtex.account,
+            parentQuote: parentQuoteId,
+          })
+
+          const {
+            DocumentId: markerplaceQuoteId,
+          } = await masterdata.createDocument({
+            dataEntity: QUOTE_DATA_ENTITY,
+            fields: marketplaceQuote,
+            schema: SCHEMA_VERSION,
+          })
+
+          childrenQuoteIds.push(markerplaceQuoteId)
+        }
+
         const sellerQuoteIds = await Promise.all(
           Object.entries(quoteBySeller).map(async ([seller, sellerQuote]) => {
             const sellerQuoteObject = createQuoteObject({
               ...quoteCommonFields,
               ...sellerQuote,
-              seller,
               parentQuote: parentQuoteId,
             })
 
@@ -169,10 +213,15 @@ export const Mutation = {
           })
         )
 
-        if (sellerQuoteIds.length) {
+        childrenQuoteIds.push(...sellerQuoteIds)
+
+        if (childrenQuoteIds.length) {
           await masterdata.updatePartialDocument({
             dataEntity: QUOTE_DATA_ENTITY,
-            fields: { hasChildren: true },
+            fields: {
+              hasChildren: true,
+              childrenQuantity: childrenQuoteIds.length,
+            },
             id: parentQuoteId,
             schema: SCHEMA_VERSION,
           })
@@ -341,6 +390,14 @@ export const Mutation = {
         })
         .then((res: any) => res)
 
+      const sellerQuotesController = new SellerQuotesController(ctx)
+
+      if (existingQuote.parentQuote) {
+        sellerQuotesController.handleParentQuoteSubtotalAndStatus(
+          existingQuote.parentQuote
+        )
+      }
+
       const users = updateHistory.map((anUpdate) => anUpdate.email)
       const uniqueUsers = [
         ...new Set(
@@ -404,15 +461,45 @@ export const Mutation = {
 
     try {
       // GET QUOTE DATA
-      const quote: Quote = await masterdata.getDocument({
+      const mainQuote: Quote = await masterdata.getDocument({
         dataEntity: QUOTE_DATA_ENTITY,
         fields: QUOTE_FIELDS,
         id,
       })
 
-      checkQuoteStatus(quote)
+      const quotes: Quote[] = []
+      const items: QuoteItem[] = []
 
-      const { items, salesChannel } = quote
+      if (mainQuote.hasChildren) {
+        const sellerQuotesController = new SellerQuotesController(ctx)
+        const childrenQuotes = await sellerQuotesController.getAllChildrenQuotes(
+          id
+        )
+
+        let errorsCount = 0
+
+        for (const quote of childrenQuotes) {
+          try {
+            checkQuoteStatus(quote)
+            quotes.push(quote)
+          } catch (e) {
+            if (++errorsCount === childrenQuotes.length) {
+              throw e
+            }
+
+            continue
+          }
+        }
+      } else {
+        checkQuoteStatus(mainQuote)
+        quotes.push(mainQuote)
+      }
+
+      for (const quote of quotes) {
+        items.push(...quote.items)
+      }
+
+      const { salesChannel } = mainQuote
 
       // CLEAR CURRENT CART
       if (orderFormId !== 'default-order-form') {
@@ -511,14 +598,16 @@ export const Mutation = {
         useHeaders
       )
 
-      const metricParams: UseQuoteMetricsParams = {
-        quote,
-        orderFormId,
-        account,
-        userEmail: sessionData?.namespaces?.profile?.email?.value,
-      }
+      for (const quote of quotes) {
+        const metricParams: UseQuoteMetricsParams = {
+          quote,
+          orderFormId,
+          account,
+          userEmail: sessionData?.namespaces?.profile?.email?.value,
+        }
 
-      sendUseQuoteMetric(ctx, metricParams)
+        sendUseQuoteMetric(ctx, metricParams)
+      }
     } catch (error) {
       logger.error({
         error,

--- a/node/resolvers/mutations/index.ts
+++ b/node/resolvers/mutations/index.ts
@@ -109,8 +109,11 @@ export const Mutation = {
           )
       )
 
-      const oneSellerQuoteAndNoRemainingItems = sellerQuotesQuantity === 1 && !remainingItems.length;
-      const isOnlyOneQuote = !sellerQuotesQuantity || oneSellerQuoteAndNoRemainingItems;
+      const oneSellerQuoteAndNoRemainingItems =
+        sellerQuotesQuantity === 1 && !remainingItems.length
+
+      const isOnlyOneQuote =
+        !sellerQuotesQuantity || oneSellerQuoteAndNoRemainingItems
 
       const [firstSellerQuote] = Object.values(quoteBySeller)
 
@@ -154,8 +157,8 @@ export const Mutation = {
           parentQuoteId,
           parentQuote.creationDate
         )
-      } 
-      
+      }
+
       if (!isOnlyOneQuote) {
         const childrenQuoteIds: string[] = []
 
@@ -269,12 +272,11 @@ export const Mutation = {
         error,
         message: 'createQuote-error ',
       })
-      
-      if (error.message) 
-        throw new GraphQLError(error.message)
-      if (error.response?.data?.message) 
-        throw new GraphQLError(error.response.data.message)
-      throw new GraphQLError(error)
+
+      const errorMessage =
+        error.message || error.response?.data?.message || error
+
+      throw new GraphQLError(errorMessage)
     }
   },
   updateQuote: async (

--- a/node/resolvers/queries/index.ts
+++ b/node/resolvers/queries/index.ts
@@ -313,7 +313,7 @@ export const Query = {
     const sellerQuotesController = new SellerQuotesController(ctx)
 
     try {
-      return sellerQuotesController.getAllChildrenQuotes(
+      return await sellerQuotesController.getAllChildrenQuotes(
         id,
         sortOrder,
         sortedBy

--- a/node/resolvers/queries/index.ts
+++ b/node/resolvers/queries/index.ts
@@ -8,6 +8,7 @@ import {
 } from '../../constants'
 import GraphQLError from '../../utils/GraphQLError'
 import { checkConfig } from '../utils/checkConfig'
+import SellerQuotesController from '../utils/sellerQuotesController'
 
 // This function checks if given email is an user part of a buyer org.
 export const isUserPartOfBuyerOrg = async (email: string, ctx: Context) => {
@@ -295,35 +296,28 @@ export const Query = {
     _: any,
     {
       id,
-      page,
-      pageSize,
       sortOrder,
       sortedBy,
     }: {
       id: string
-      page: number
-      pageSize: number
       sortOrder: string
       sortedBy: string
     },
     ctx: Context
   ) => {
     const {
-      clients: { masterdata },
       vtex: { logger },
     } = ctx
 
     await checkConfig(ctx)
+    const sellerQuotesController = new SellerQuotesController(ctx)
 
     try {
-      return await masterdata.searchDocumentsWithPaginationInfo({
-        dataEntity: QUOTE_DATA_ENTITY,
-        fields: QUOTE_FIELDS,
-        pagination: { page, pageSize },
-        schema: SCHEMA_VERSION,
-        sort: `${sortedBy} ${sortOrder}`,
-        where: `parentQuote=${id}`,
-      })
+      return sellerQuotesController.getAllChildrenQuotes(
+        id,
+        sortOrder,
+        sortedBy
+      )
     } catch (error) {
       logger.error({
         error,
@@ -381,5 +375,35 @@ export const Query = {
     }
 
     return settings
+  },
+  checkSellerQuotes: async (
+    _: void,
+    { sellers }: { sellers: string[] },
+    ctx: Context
+  ) => {
+    // guarantee at least the marketplace seller to use your name if necessary
+    const allSellers = sellers.filter((seller) => seller !== '1')
+
+    allSellers.push('1')
+
+    const verifiedSellers = await Promise.all(
+      allSellers.map(async (seller) => {
+        if (seller === '1') {
+          return ctx.clients.seller.getSeller(seller)
+        }
+
+        const verifyResponse = await ctx.clients.sellerQuotes
+          .verifyQuoteSettings(seller)
+          .catch(() => null)
+
+        if (verifyResponse?.receiveQuotes) {
+          return ctx.clients.seller.getSeller(seller)
+        }
+
+        return null
+      })
+    )
+
+    return verifiedSellers.filter(Boolean)
   },
 }

--- a/node/resolvers/routes/seller/getSellerQuotesPaginated.ts
+++ b/node/resolvers/routes/seller/getSellerQuotesPaginated.ts
@@ -23,7 +23,7 @@ export async function getSellerQuotesPaginated(ctx: Context, next: NextFn) {
     const searchTerm = `*${search.replace(/'/g, '').split(/\s+/).join('*')}*`
 
     filters.push(
-      `(referenceName='${searchTerm}' OR creatorEmail='${searchTerm}')`
+      `(referenceName='${searchTerm}' OR creatorEmail='${searchTerm}' OR creatorName='${searchTerm}')`
     )
   }
 

--- a/node/resolvers/utils/sellerQuotesController.ts
+++ b/node/resolvers/utils/sellerQuotesController.ts
@@ -170,15 +170,17 @@ export default class SellerQuotesController {
       (quote) => quote.status === 'pending'
     )
 
-    const status = isEverySameStatus
-      ? childrenQuotes[0].status
-      : isEverySameStatusExceptDeclined
-      ? quotesExceptDeclined[0].status
-      : isSomePending
-      ? 'pending'
-      : isSomeRevised
-      ? 'revised'
-      : undefined
+    let status: string | undefined
+
+    if (isEverySameStatus) {
+      status = childrenQuotes[0].status
+    } else if (isEverySameStatusExceptDeclined) {
+      status = quotesExceptDeclined[0].status
+    } else if (isSomePending) {
+      status = 'pending'
+    } else if (isSomeRevised) {
+      status = 'revised'
+    }
 
     const lastUpdate = new Date().toISOString()
 

--- a/node/resolvers/utils/sellerQuotesController.ts
+++ b/node/resolvers/utils/sellerQuotesController.ts
@@ -19,7 +19,10 @@ type GetQuotesArgs = {
 }
 
 export default class SellerQuotesController {
-  constructor(private readonly ctx: Context, private readonly seller: string) {}
+  constructor(
+    private readonly ctx: Context | EventBroadcastContext,
+    private readonly seller?: string
+  ) {}
 
   private async getSellerQuotes({
     page = 1,
@@ -59,7 +62,11 @@ export default class SellerQuotesController {
     return { organizationName, costCenterName }
   }
 
-  private async getAllChildrenQuotes(parentQuote: string) {
+  public async getAllChildrenQuotes(
+    parentQuote: string,
+    sortOrder = 'DESC',
+    sortedBy = 'lastUpdate'
+  ) {
     const result: Quote[] = []
 
     const getQuotes = async (page = 1) => {
@@ -67,8 +74,9 @@ export default class SellerQuotesController {
         dataEntity: QUOTE_DATA_ENTITY,
         schema: SCHEMA_VERSION,
         pagination: { page, pageSize: 100 },
-        fields: ['subtotal'],
+        fields: QUOTE_FIELDS,
         where: `parentQuote=${parentQuote}`,
+        sort: `${sortedBy} ${sortOrder}`,
       })
 
       if (quotes.length) {
@@ -96,7 +104,7 @@ export default class SellerQuotesController {
     page,
     pageSize,
     where,
-    sort = 'creationDate DESC',
+    sort = 'lastUpdate DESC',
   }: {
     page: number
     pageSize: number
@@ -130,9 +138,59 @@ export default class SellerQuotesController {
     }
   }
 
-  public async saveSellerQuote(id: string, fields: Partial<Quote>) {
-    const currentQuote = await this.getSellerQuote(id)
+  public async handleParentQuoteSubtotalAndStatus(parentQuote: string) {
+    const childrenQuotes = await this.getAllChildrenQuotes(parentQuote)
 
+    if (!childrenQuotes?.length) return
+
+    const sumSubtotal = childrenQuotes.reduce(
+      (acc, quote) => acc + quote.subtotal,
+      0
+    )
+
+    const isEverySameStatus = childrenQuotes.every(
+      (quote) => quote.status === childrenQuotes[0].status
+    )
+
+    const quotesExceptDeclined = childrenQuotes.filter(
+      (quote) => quote.status !== 'declined'
+    )
+
+    const isEverySameStatusExceptDeclined =
+      !!quotesExceptDeclined.length &&
+      quotesExceptDeclined.every(
+        (quote) => quote.status === quotesExceptDeclined[0].status
+      )
+
+    const isSomeRevised = childrenQuotes.some(
+      (quote) => quote.status === 'revised'
+    )
+
+    const isSomePending = childrenQuotes.some(
+      (quote) => quote.status === 'pending'
+    )
+
+    const status = isEverySameStatus
+      ? childrenQuotes[0].status
+      : isEverySameStatusExceptDeclined
+      ? quotesExceptDeclined[0].status
+      : isSomePending
+      ? 'pending'
+      : isSomeRevised
+      ? 'revised'
+      : undefined
+
+    const lastUpdate = new Date().toISOString()
+
+    this.ctx.clients.masterdata.updatePartialDocument({
+      dataEntity: QUOTE_DATA_ENTITY,
+      schema: SCHEMA_VERSION,
+      fields: { subtotal: sumSubtotal, status, lastUpdate },
+      id: parentQuote,
+    })
+  }
+
+  public async saveSellerQuote(id: string, fields: Partial<Quote>) {
     await this.ctx.clients.masterdata.updatePartialDocument({
       dataEntity: QUOTE_DATA_ENTITY,
       schema: SCHEMA_VERSION,
@@ -140,32 +198,10 @@ export default class SellerQuotesController {
       id,
     })
 
-    const { subtotal } = currentQuote
-    const subtotalDelta = (fields?.subtotal ?? subtotal) - subtotal
     const { parentQuote } = fields
 
-    if (!subtotalDelta || !parentQuote) return
-
-    /**
-     * The seller can update the subtotal of your quote changing items
-     * prices. Therefore, it is necessary to update the subtotal of the
-     * parent quote. The call below is asynchronous as there is no need
-     * to stop the flow because of this operation.
-     */
-    this.getAllChildrenQuotes(parentQuote)
-      .then((childrenQuotes) => {
-        const sumSubtotal = childrenQuotes.reduce(
-          (acc, quote) => acc + quote.subtotal,
-          0
-        )
-
-        this.ctx.clients.masterdata.updatePartialDocument({
-          dataEntity: QUOTE_DATA_ENTITY,
-          schema: SCHEMA_VERSION,
-          fields: { subtotal: sumSubtotal },
-          id: parentQuote,
-        })
-      })
-      .catch(() => null)
+    if (parentQuote) {
+      this.handleParentQuoteSubtotalAndStatus(parentQuote)
+    }
   }
 }

--- a/node/typings.d.ts
+++ b/node/typings.d.ts
@@ -2,6 +2,7 @@ interface Quote {
   id: string
   referenceName: string
   creatorEmail: string
+  creatorName: string
   creatorRole: string
   creationDate: string
   expirationDate: string
@@ -16,8 +17,10 @@ interface Quote {
   viewedByCustomer: boolean
   salesChannel: string | null
   seller?: string | null
+  sellerName?: string | null
   parentQuote?: string | null
   hasChildren?: boolean | null
+  childrenQuantity?: number | null
 }
 
 interface QuoteUpdate {
@@ -111,8 +114,8 @@ interface Settings {
     cronWorkspace?: string
     quotesManagedBy?: string
   }
-  hasSplittingQuoteFieldsInSchema?: boolean
   schemaVersion: string
+  schemaHash: string | null
   templateHash: string | null
 }
 
@@ -121,6 +124,8 @@ interface SessionData {
     profile: {
       id: { value: string }
       email: { value: string }
+      firstName: { value: string }
+      lastName: { value: string }
     }
     account: {
       accountName: { value: string }
@@ -135,6 +140,8 @@ interface SessionData {
 interface SellerQuoteInput {
   items: QuoteItem[]
   subtotal: number
+  seller: string
+  sellerName: string
 }
 
 type SellerQuoteMap = Record<string, SellerQuoteInput>
@@ -147,4 +154,9 @@ interface SellerQuoteNotifyInput {
   quoteId: string
   marketplaceAccount: string
   creationDate: string
+}
+
+interface Seller {
+  id: string
+  name: string
 }

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1522,7 +1522,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
#### What problem is this solving?

This pull request adds the modifications and features made in this [one](https://github.com/vtex-apps/b2b-quotes-graphql/pull/66).

- Add fields creatorName, sellerName and childrenQuantity on quote entity
- Saving masterdata schema hash in settings to update when it changes
- Create a new quote to marketplace responsibility for remaining items, if exist, when splitting a quote
- Create a new query to check sellers quotes on frontend
- Handle parent quote status and subtotal when updating splitted quotes
- Get all children quotes ordered by lastUpdate DESC once on getChildrenQuotes

#### How to test it?

- Link this branch on account bravtexfashionb2b in workspace b2bsellerquoteslocalhost
- Link branch [feat/create-quote-settings-ui](https://github.com/vtex-apps/b2b-seller-quotes/tree/feat/create-quote-settings-ui) of b2b-seller-quotes app on account shopfashion568 in workspace b2bsellerquoteslocalhost (the same workspace name)
- Create a quote that contains product of seller shopfashion568 ([example of seller product](https://b2bsellerquoteslocalhost--bravtexfashionb2b.myvtex.com/camisa-feminina-gray/p)) and products from marketplace responsibility.
- Search documents of quotes entity of b2b-quotes-graphql app to view created quotes with their `sellerName`'s and `creatorName`'s

[Workspace](https://b2bsellerquoteslocalhost--bravtexfashionb2b.myvtex.com)
