### PR TITLE
Fix getOrgSalesAdminEmail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix getOrgSalesAdminEmail
 
 ## [2.9.0] - 2025-01-23
 

--- a/node/utils/message.ts
+++ b/node/utils/message.ts
@@ -27,14 +27,14 @@ const getOrgSalesAdminEmail = async (
   }
 
   const {
-    data: { getOrgSalesAdminEmailResult },
+    data: { listUsersPaginated },
   }: any = await storefrontPermissions.getOrgSalesAdminEmail({
     roleId: role.id,
     ...(organizationId && { organizationId }),
   })
 
   // we only return the first page of sales-admin users (25)
-  return getOrgSalesAdminEmailResult.data
+  return listUsersPaginated.data
 }
 
 const getOrgAndCostCenterNames = async (


### PR DESCRIPTION
#### What problem is this solving?

Fix the error to get the sales representative emails when sending the quote created email

#### How to test it?

[Workspace](https://quotesemail--b2bstore005.myvtex.com/)