### PR TITLE
chore: major update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Update dependency major version. If you are updating to this major version, make sure to update the following apps (if you have then installed) to the following major versions:
+    - vtex.b2b-admin-customers@2.x
+    - vtex.b2b-checkout-settings@3.x
+    - vtex.b2b-my-account@2.x
+    - vtex.b2b-orders-history@2.x
+    - vtex.b2b-organizations@3.x
+    - vtex.b2b-organizations-graphql@2.x
+    - vtex.b2b-quotes@3.x
+    - vtex.b2b-quotes-graphql@4.x
+    - vtex.b2b-suite@2.x
+    - vtex.b2b-theme@5.x
+    - vtex.storefront-permissions-components@2.x
+    - vtex.storefront-permissions-ui@1.x
+
 ## [3.0.0] - 2025-05-27
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -10,8 +10,8 @@
     "docs": "0.x"
   },
   "dependencies": {
-    "vtex.storefront-permissions": "2.x",
-    "vtex.b2b-organizations-graphql": "1.x",
+    "vtex.storefront-permissions": "3.x",
+    "vtex.b2b-organizations-graphql": "2.x",
     "vtex.orders-broadcast": "0.x"
   },
   "registries": [

--- a/node/clients/organizations.ts
+++ b/node/clients/organizations.ts
@@ -5,7 +5,7 @@ import { getTokenToHeader } from './index'
 
 export default class Organizations extends AppGraphQLClient {
   constructor(ctx: IOContext, options?: InstanceOptions) {
-    super('vtex.b2b-organizations-graphql@1.x', ctx, options)
+    super('vtex.b2b-organizations-graphql@2.x', ctx, options)
   }
 
   public getOrganizationById = async (id: string): Promise<any> => {
@@ -45,8 +45,8 @@ export default class Organizations extends AppGraphQLClient {
   private readonly getPersistedQuery = () => {
     return {
       persistedQuery: {
-        provider: 'vtex.b2b-organizations-graphql@1.x',
-        sender: 'vtex.b2b-quotes@2.x',
+        provider: 'vtex.b2b-organizations-graphql@2.x',
+        sender: 'vtex.b2b-quotes@3.x',
       },
     }
   }

--- a/node/clients/storefrontPermissions.ts
+++ b/node/clients/storefrontPermissions.ts
@@ -52,7 +52,7 @@ export const QUERIES = {
 
 export default class StorefrontPermissions extends AppGraphQLClient {
   constructor(ctx: IOContext, options?: InstanceOptions) {
-    super('vtex.storefront-permissions@2.x', ctx, options)
+    super('vtex.storefront-permissions@3.x', ctx, options)
   }
 
   public checkUserPermission = async (): Promise<any> => {
@@ -91,8 +91,8 @@ export default class StorefrontPermissions extends AppGraphQLClient {
   private readonly getPersistedQuery = () => {
     return {
       persistedQuery: {
-        provider: 'vtex.storefront-permissions@2.x',
-        sender: 'vtex.b2b-quotes@2.x',
+        provider: 'vtex.storefront-permissions@3.x',
+        sender: 'vtex.b2b-quotes@3.x',
       },
     }
   }


### PR DESCRIPTION
**What problem is this solving?**

Generating new major version. This new version includes ACL feature. Now the following permissions are needed to view/edit organizations within the admin UI app:
`Buyer Organizations / buyer_organization_view`
`Buyer Organizations / buyer_organization_edit`

If you are updating to this major version, make sure to update the following apps (if you have then installed) to the following major versions:
    - vtex.b2b-admin-customers@2.x
    - vtex.b2b-checkout-settings@3.x
    - vtex.b2b-my-account@2.x
    - vtex.b2b-orders-history@2.x
    - vtex.b2b-organizations@3.x
    - vtex.b2b-organizations-graphql@2.x
    - vtex.b2b-quotes@3.x
    - vtex.b2b-quotes-graphql@4.x
    - vtex.b2b-suite@2.x
    - vtex.b2b-theme@5.x
    - vtex.storefront-permissions-components@2.x
    - vtex.storefront-permissions-ui@1.x