### PR TITLE
Fix `itemsAdded` to skip giftItems when creating the order items.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `itemsAdded` to skip giftItems when creating the order items.
+
 ## [4.0.4] - 2026-02-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix `itemsAdded` to skip giftItems when creating the order items.
 
+### Changed
+
+- Added unitMultiplier to QuoteItem schema and typings
+- Fixed subtotal calculations to include unitMultiplier
+- Updated quote application logic to support unitMultiplier
+
 ## [4.0.4] - 2026-02-04
 
 ### Added

--- a/graphql/quote.graphql
+++ b/graphql/quote.graphql
@@ -18,6 +18,7 @@ input QuoteItemInput {
   quantity: Int
   sellingPrice: Float
   seller: String
+  unitMultiplier: Float
 }
 
 input QuoteUpdateInput {
@@ -87,6 +88,7 @@ type QuoteItem {
   quantity: Int
   sellingPrice: Float
   seller: String
+  unitMultiplier: Float
 }
 
 type Seller {

--- a/node/resolvers/mutations/index.ts
+++ b/node/resolvers/mutations/index.ts
@@ -593,7 +593,7 @@ export const Mutation = {
 
       const orderItems: any[] = []
 
-      itemsAdded.forEach((_item: any, key: number) => {
+      itemsAdded.filter((item: any) => !item.isGift).forEach((_item: any, key: number) => {
         const sellingData = sellingPriceMap[String(key + 1)]
 
         orderItems.push({

--- a/node/resolvers/mutations/index.ts
+++ b/node/resolvers/mutations/index.ts
@@ -592,12 +592,16 @@ export const Mutation = {
       )
 
       const orderItems: any[] = []
+      let quoteItemIndex = 0
 
-      itemsAdded.filter((item: any) => !item.isGift).forEach((_item: any, key: number) => {
-        const sellingData = sellingPriceMap[String(key + 1)]
+      itemsAdded.forEach((item: any, realIndex: number) => {
+        if (item.isGift) return
+
+        quoteItemIndex++
+        const sellingData = sellingPriceMap[String(quoteItemIndex)]
 
         orderItems.push({
-          index: key,
+          index: realIndex,
           price: sellingData?.price,
           quantity: sellingData?.quantity,
         })

--- a/node/typings.d.ts
+++ b/node/typings.d.ts
@@ -43,6 +43,7 @@ interface QuoteItem {
   quantity: number
   sellingPrice: number
   seller: string
+  unitMultiplier?: number
 }
 
 interface ReqContext {

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -2254,9 +2254,9 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-"stats-lite@github:vtex/node-stats-lite#dist":
-  version "2.2.0"
-  resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
+stats-lite@vtex/node-stats-lite#dist:
+  version "2.2.1"
+  resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/a0b5ee91861f31b6ec845146b4906faf5172c430"
   dependencies:
     isnumber "~1.0.0"
 


### PR DESCRIPTION
#### What problem is this solving?

The `useQuote` mutation was failing with **CHK0023 "Cantidad de item inválida"** when trying to add items to cart. Gift items were being included in the `orderItems` array sent to the price update API, but they shouldn't have price/quantity values set manually since they're automatically managed by promotions.
Also Add support for `unitMultiplier` on `type QuoteItem` and `QuoteItemInput`.

#### How to test it?

1. Create a quote that includes gift items from promotions
2. Use the quote via `useQuote` mutation
3. Verify items are added to cart without errors

[Workspace](Link goes here!)

#### Screenshots or example usage:

**Before:** 
```json
{"orderItems":[{"index":8},{"index":9}]}  // ❌ Gift items with undefined price/quantity
```

**After:**
```json
// Gift items are filtered out from orderItems array ✅
```


https://github.com/user-attachments/assets/6a7c50e3-ba4e-4f25-9dc8-0ab67f1edccd

https://github.com/user-attachments/assets/bf87d2eb-3568-42b4-ad5c-632c158280bd


https://github.com/user-attachments/assets/765ce36b-8a4e-48c7-8bbc-35c3684bfa85


https://github.com/user-attachments/assets/8d545329-5c48-464a-9b58-4f00e50e66a2




#### Describe alternatives you've considered, if any.

Could have set price/quantity to 0 for gifts, but filtering them out is cleaner since gift prices are controlled by promotions.

#### Related to / Depends on

Fixes the root cause identified in useQuote error logs (CHK0023).