### PR TITLE
[B2BTEAM-3599] Introducing major-based schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ react/package-lock.json
 node/package-lock.json
 node/node_modules
 .vscode/
+.cursor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Scoped Master Data schema sync hash storage per app major version (`settings-v{N}` VBase key) to prevent infinite sync loops when multiple app majors coexist in the same account
+- Bumped quotes Master Data schema version to align with app major 4 (`SCHEMA_VERSION` → `v4.3`)
+
 ## [4.0.6] - 2026-03-10
 
 ### Fixed

--- a/node/constants.ts
+++ b/node/constants.ts
@@ -1,5 +1,5 @@
 export const APP_NAME = 'b2b-quotes-graphql'
-export const SCHEMA_VERSION = 'v1.3'
+export const SCHEMA_VERSION = 'v4.3'
 export const QUOTE_DATA_ENTITY = 'quotes'
 export const B2B_USER_SCHEMA_VERSION = 'v0.1.2'
 export const B2B_USER_DATA_ENTITY = 'b2b_users'
@@ -74,6 +74,16 @@ export const routes = {
 export const getAppId = (): string => {
   return process.env.VTEX_APP_ID ?? ''
 }
+
+export const getAppMajorVersion = (): string => {
+  const appId = getAppId()
+  const version = appId.split('@')[1] ?? ''
+
+  return version.split('.')[0] || '0'
+}
+
+export const getSettingsVBaseKey = (): string =>
+  `settings-v${getAppMajorVersion()}`
 
 export const schema = {
   properties: {

--- a/node/constants.ts
+++ b/node/constants.ts
@@ -1,7 +1,7 @@
 export const APP_NAME = 'b2b-quotes-graphql'
 export const SCHEMA_VERSION = 'v4.3'
 export const QUOTE_DATA_ENTITY = 'quotes'
-export const B2B_USER_SCHEMA_VERSION = 'v0.1.2'
+export const B2B_USER_SCHEMA_VERSION = 'v3.1.2'
 export const B2B_USER_DATA_ENTITY = 'b2b_users'
 export const CRON_EXPRESSION = '0 */12 * * *'
 

--- a/node/package.json
+++ b/node/package.json
@@ -9,7 +9,7 @@
     "ramda": "^0.25.0",
     "atob": "^2.1.2",
     "axios": "0.27.2",
-    "@vtex/api": "6.50.1"
+    "@vtex/api": "6.51.0"
   },
   "devDependencies": {
     "@types/atob": "^2.1.2",

--- a/node/resolvers/mutations/index.ts
+++ b/node/resolvers/mutations/index.ts
@@ -2,6 +2,7 @@ import { map, groupBy, values } from 'ramda'
 
 import {
   APP_NAME,
+  getSettingsVBaseKey,
   QUOTE_DATA_ENTITY,
   QUOTE_FIELDS,
   routes,
@@ -657,7 +658,7 @@ export const Mutation = {
     try {
       settings = await vbase.getJSON<Settings | null>(
         APP_NAME,
-        'settings',
+        getSettingsVBaseKey(),
         true
       )
     } catch (error) {
@@ -684,7 +685,7 @@ export const Mutation = {
     }
 
     try {
-      await vbase.saveJSON(APP_NAME, 'settings', newSettings)
+      await vbase.saveJSON(APP_NAME, getSettingsVBaseKey(), newSettings)
     } catch (error) {
       logger.error({
         error,

--- a/node/resolvers/queries/index.ts
+++ b/node/resolvers/queries/index.ts
@@ -2,6 +2,7 @@ import {
   APP_NAME,
   B2B_USER_DATA_ENTITY,
   B2B_USER_SCHEMA_VERSION,
+  getSettingsVBaseKey,
   QUOTE_DATA_ENTITY,
   QUOTE_FIELDS,
   SCHEMA_VERSION,
@@ -358,7 +359,7 @@ export const Query = {
     try {
       settings = await vbase.getJSON<Settings | null>(
         APP_NAME,
-        'settings',
+        getSettingsVBaseKey(),
         true
       )
     } catch (error) {

--- a/node/resolvers/utils/checkConfig.ts
+++ b/node/resolvers/utils/checkConfig.ts
@@ -3,6 +3,7 @@ import { toHash } from '../../utils'
 import {
   APP_NAME,
   CRON_EXPRESSION,
+  getSettingsVBaseKey,
   QUOTE_DATA_ENTITY,
   SCHEMA_VERSION,
   routes,
@@ -348,7 +349,11 @@ export const checkConfig = async (ctx: Context) => {
   const currTemplateHash = toHash(templates)
 
   try {
-    settings = await vbase.getJSON<Settings | null>(APP_NAME, 'settings', true)
+    settings = await vbase.getJSON<Settings | null>(
+      APP_NAME,
+      getSettingsVBaseKey(),
+      true
+    )
   } catch (error) {
     logger.error({
       error,
@@ -377,7 +382,7 @@ export const checkConfig = async (ctx: Context) => {
   changed = initializationResult.changed
 
   if (changed) {
-    await vbase.saveJSON(APP_NAME, 'settings', settings)
+    await vbase.saveJSON(APP_NAME, getSettingsVBaseKey(), settings)
   }
 
   await checkAndCreateQuotesConfig(ctx)

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -591,10 +591,10 @@
   resolved "https://registry.yarnpkg.com/@types/shimmer/-/shimmer-1.2.0.tgz#9b706af96fa06416828842397a70dfbbf1c14ded"
   integrity sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==
 
-"@vtex/api@6.50.1":
-  version "6.50.1"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.50.1.tgz#a86578982a7aac7c7a8df2b9ec3df18bc43f01f2"
-  integrity sha512-4IlmYwCXKpkdpN2KN6NkPuRwnjet3ilSoET3PBOTTdZqE/mnuvIxRZRaQy+Yp7Gxu0XKAVdp/8SQJhsJaa6Unw==
+"@vtex/api@6.51.0":
+  version "6.51.0"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.51.0.tgz#97aeb306619ff49fd890595b90568883eaf77d83"
+  integrity sha512-vRWKB4G1FPPt67rwWx+xGLanuP5y+M9SVmbKu3PzlTrqgq/aW/mINSUGa/Nhm64UBqIQCkVic7/smZ7kKFq52w==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -2254,7 +2254,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.1"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/a0b5ee91861f31b6ec845146b4906faf5172c430"
   dependencies:


### PR DESCRIPTION
#### What problem is this solving?

When two different **major versions** of `b2b-quotes-graphql` are installed in the same VTEX account, they share a single VBase key (`settings`) for Master Data schema auto-sync. Each major has different schema definitions and versions, so they produce different hashes. Each major overwrites the other's hash on every request, causing an **infinite schema sync loop**.

Additionally, major 4 was still using the legacy schema version `v1.3`, which could be overwritten or conflict with schemas from other installed majors.

This change:
- Scopes the VBase settings key per app major (`settings-v{N}`, e.g. `settings-v4`)
- Bumps the quotes Master Data schema version to `v4.3` to align with app major 4
- Leaves `B2B_USER_SCHEMA_VERSION` at `v0.1.2` (read-only reference to `b2b-organizations`; future migration to `v3.1.2` is out of scope)

---

#### How to test it?

[Workspace](https://wender--b2bstoreqa.myvtex.com/admin/graphql-ide)

1. Link the branch: `vtex link`
2. Trigger any operation that calls `checkConfig` (e.g. `getAppSettings` or `getQuotes` GraphQL query)
3. **VBase:** Confirm a new key `settings-v4` exists in bucket `b2b-quotes-graphql` (legacy `settings` key is intentionally left untouched)
4. **Master Data:** Confirm schema `v4.3` exists for entity `quotes` via MD API
5. **CRUD:** Create and read a quote — operations should succeed using `SCHEMA_VERSION`
6. **Logs:** Confirm schema sync runs **once**, not repeatedly on every request
7. _(Optional)_ With two majors installed in the same account, confirm each major maintains its own `settings-v{N}` key without interfering with the other

---

#### Screenshots or example usage:
<img width="1101" height="407" alt="image" src="https://github.com/user-attachments/assets/3bcca58c-cee5-4de3-ad24-2de56445e719" />
<img width="1015" height="470" alt="image" src="https://github.com/user-attachments/assets/93e3bae4-675d-4e62-befa-6d21d17ddf22" />
<img width="1017" height="908" alt="image" src="https://github.com/user-attachments/assets/f02a9af2-976d-4a1e-a1a9-99dfc1c1aa77" />
