### PR TITLE
feat: send priceToken on addToCart in useQuote [B2BTEAM-3733]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ react/package-lock.json
 node/package-lock.json
 node/node_modules
 .vscode/
+.claude
+.cursor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- [B2BTEAM-3733] Send `priceToken` (signed price) when adding the quote items to the cart in `useQuote`, so Checkout can still build the cart while Pricing is unavailable. The token is fetched from the catalog search at the moment the quote is applied and is optional: if it is not available, items are added exactly as before.
+
 ## [4.0.6] - 2026-03-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- [B2BTEAM-3733] `useQuote` now adds the quote items to the cart with `PATCH /orderForm/{id}/items` instead of `POST`. Only `PATCH` honors `priceToken`, and `POST` is no longer meant to be used. Items are still added as new items, since no `index` is sent.
+- [B2BTEAM-3733] `useQuote` now uses `PATCH /orderForm/{id}/items` for both cart operations: adding the quote items (no `index` sent) and overwriting their price with the negotiated one (`index` sent, replacing `POST /orderForm/{id}/items/update`). `PATCH` is the only route that honors `priceToken`, and the previous routes are no longer meant to be used. The price payload now also carries `id` and `seller`, which `PATCH` requires.
 
 ## [4.0.6] - 2026-03-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [B2BTEAM-3733] Send `priceToken` (signed price) when adding the quote items to the cart in `useQuote`, so Checkout can still build the cart while Pricing is unavailable. The token is fetched from the catalog search at the moment the quote is applied and is optional: if it is not available, items are added exactly as before.
 
+### Changed
+
+- [B2BTEAM-3733] `useQuote` now adds the quote items to the cart with `PATCH /orderForm/{id}/items` instead of `POST`. Only `PATCH` honors `priceToken`, and `POST` is no longer meant to be used. Items are still added as new items, since no `index` is sent.
+
 ## [4.0.6] - 2026-03-10
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -89,6 +89,13 @@
     {
       "name": "outbound-access",
       "attrs": {
+        "host": "{{account}}.vtexcommercestable.com.br",
+        "path": "/api/catalog_system/pub/*"
+      }
+    },
+    {
+      "name": "outbound-access",
+      "attrs": {
         "host": "api.vtex.com",
         "path": "/api/dataentities/*"
       }

--- a/node/clients/catalog.ts
+++ b/node/clients/catalog.ts
@@ -1,0 +1,55 @@
+import type {
+  InstanceOptions,
+  IOContext,
+  RequestTracingConfig,
+} from '@vtex/api'
+import { JanusClient } from '@vtex/api'
+
+import { APP_NAME } from '../constants'
+import { createTracing } from '../utils/index'
+
+const SEARCH_ENDPOINT = '/api/catalog_system/pub/products/search'
+
+// The catalog search is only used to enrich the cart with price tokens, so it
+// must never slow down or break the flow that depends on it.
+const CATALOG_CLIENT_OPTIONS: InstanceOptions = {
+  retries: 1,
+  timeout: 3000,
+}
+
+export default class Catalog extends JanusClient {
+  constructor(ctx: IOContext, options?: InstanceOptions) {
+    super(ctx, {
+      ...options,
+      ...CATALOG_CLIENT_OPTIONS,
+      headers: {
+        ...options?.headers,
+        Accept: 'application/json',
+      },
+    })
+  }
+
+  /**
+   * Searches products by SKU id. The response carries the signed price
+   * (`sellers[].commertialOffer.PriceToken`) generated for this request.
+   */
+  public searchBySkuIds(
+    skuIds: string[],
+    salesChannel?: string | null,
+    tracingConfig?: RequestTracingConfig
+  ) {
+    const metric = `${APP_NAME}-catalogSearchBySkuIds`
+
+    const filters = skuIds.map((skuId) => `fq=skuId:${skuId}`).join('&')
+    const salesChannelQueryString = salesChannel ? `&sc=${salesChannel}` : ''
+    const pagination = `&_from=0&_to=${skuIds.length - 1}`
+
+    return this.http.get<CatalogProduct[]>(
+      `${SEARCH_ENDPOINT}?${filters}${salesChannelQueryString}${pagination}`,
+      {
+        metric,
+        tracing: createTracing(metric, tracingConfig),
+      }
+    )
+  }
+}

--- a/node/clients/index.ts
+++ b/node/clients/index.ts
@@ -5,6 +5,7 @@ import AnalyticsClient from './analytics'
 import RequestHub from '../utils/Hub'
 import Identity from '../utils/Identity'
 import { Scheduler } from '../utils/Scheduler'
+import Catalog from './catalog'
 import Checkout from './checkout'
 import LMClient from './LMClient'
 import MailClient from './email'
@@ -51,6 +52,10 @@ export class Clients extends IOClients {
 
   public get vtexId() {
     return this.getOrSet('vtexId', VtexId)
+  }
+
+  public get catalog() {
+    return this.getOrSet('catalog', Catalog)
   }
 
   public get checkout() {

--- a/node/constants.ts
+++ b/node/constants.ts
@@ -50,6 +50,8 @@ export const routes = {
     }`,
   addPriceToItems: (account: string, orderFormId: string) =>
     `${routes.orderForm(account)}/${orderFormId}/items/update`,
+  // Must be called with PATCH: POST does not honor `priceToken` and is no
+  // longer meant to be used.
   addToCart: (account: string, orderFormId: string) =>
     `${routes.orderForm(account)}/${orderFormId}/items/`,
   baseUrl: (account: string) =>

--- a/node/constants.ts
+++ b/node/constants.ts
@@ -5,6 +5,9 @@ export const B2B_USER_SCHEMA_VERSION = 'v0.1.2'
 export const B2B_USER_DATA_ENTITY = 'b2b_users'
 export const CRON_EXPRESSION = '0 */12 * * *'
 
+// The catalog search API returns at most 50 products per request.
+export const CATALOG_SEARCH_PAGE_SIZE = 50
+
 export const QUOTE_FIELDS = [
   'id',
   'referenceName',

--- a/node/constants.ts
+++ b/node/constants.ts
@@ -48,12 +48,12 @@ export const routes = {
     `${routes.orderForm(account)}/${orderFormId}/customData/${appId}/${
       property ?? ''
     }`,
-  addPriceToItems: (account: string, orderFormId: string) =>
-    `${routes.orderForm(account)}/${orderFormId}/items/update`,
-  // Must be called with PATCH: POST does not honor `priceToken` and is no
-  // longer meant to be used.
-  addToCart: (account: string, orderFormId: string) =>
-    `${routes.orderForm(account)}/${orderFormId}/items/`,
+  // Always call this with PATCH. It both adds items (no `index` sent) and
+  // changes their price (`index` sent), and it is the only route that honors
+  // `priceToken` - neither `POST /items` nor `POST /items/update` does, and
+  // they are no longer meant to be used.
+  cartItems: (account: string, orderFormId: string) =>
+    `${routes.orderForm(account)}/${orderFormId}/items`,
   baseUrl: (account: string) =>
     `http://${account}.vtexcommercestable.com.br/api`,
   checkoutConfig: (account: string) =>

--- a/node/package.json
+++ b/node/package.json
@@ -9,7 +9,7 @@
     "ramda": "^0.25.0",
     "atob": "^2.1.2",
     "axios": "0.27.2",
-    "@vtex/api": "6.51.0"
+    "@vtex/api": "6.50.1"
   },
   "devDependencies": {
     "@types/atob": "^2.1.2",

--- a/node/package.json
+++ b/node/package.json
@@ -9,7 +9,7 @@
     "ramda": "^0.25.0",
     "atob": "^2.1.2",
     "axios": "0.27.2",
-    "@vtex/api": "6.50.1"
+    "@vtex/api": "6.51.0"
   },
   "devDependencies": {
     "@types/atob": "^2.1.2",

--- a/node/resolvers/mutations/index.ts
+++ b/node/resolvers/mutations/index.ts
@@ -576,14 +576,17 @@ export const Mutation = {
         return priceToken ? { ...item, priceToken } : item
       })
 
-      // Tracks how often the fallback is actually available, so the rollout of
-      // the feature flag on the search API can be followed from this app too.
+      // Neither the addToCart response nor the orderForm reports whether the
+      // token was received or used, and the fallback only kicks in during a
+      // Pricing outage - so this is the only practical evidence that the tokens
+      // are getting through, and how the feature flag rollout is followed here.
       logger.info({
         message: 'useQuote-priceTokenCoverage',
         itemsWithPriceToken: orderItemsToAdd.filter(
           (item) => 'priceToken' in item
         ).length,
         totalItems: orderItemsToAdd.length,
+        salesChannel,
       })
 
       // ADD ITEMS TO CART

--- a/node/resolvers/mutations/index.ts
+++ b/node/resolvers/mutations/index.ts
@@ -576,6 +576,16 @@ export const Mutation = {
         return priceToken ? { ...item, priceToken } : item
       })
 
+      // Tracks how often the fallback is actually available, so the rollout of
+      // the feature flag on the search API can be followed from this app too.
+      logger.info({
+        message: 'useQuote-priceTokenCoverage',
+        itemsWithPriceToken: orderItemsToAdd.filter(
+          (item) => 'priceToken' in item
+        ).length,
+        totalItems: orderItemsToAdd.length,
+      })
+
       // ADD ITEMS TO CART
       const data = await hub
         .post(

--- a/node/resolvers/mutations/index.ts
+++ b/node/resolvers/mutations/index.ts
@@ -24,6 +24,7 @@ import {
   checkQuoteStatus,
   checkSession,
 } from '../utils/checkPermissions'
+import { getPriceTokens, priceTokenKey } from '../utils/priceTokens'
 import {
   createItemComparator,
   createQuoteObject,
@@ -563,13 +564,25 @@ export const Mutation = {
         )
       )
 
+      // GET SIGNED PRICES SO CHECKOUT CAN ADD THE ITEMS EVEN IF PRICING IS DOWN
+      const priceTokens = await getPriceTokens(ctx, {
+        skuIds: mergedItems.map((item) => item.id),
+        salesChannel,
+      })
+
+      const orderItemsToAdd = mergedItems.map((item) => {
+        const priceToken = priceTokens[priceTokenKey(item.id, item.seller)]
+
+        return priceToken ? { ...item, priceToken } : item
+      })
+
       // ADD ITEMS TO CART
       const data = await hub
         .post(
           `${routes.addToCart(account, orderFormId)}${salesChannelQueryString}`,
           {
             expectedOrderFormSections: ['items'],
-            orderItems: mergedItems,
+            orderItems: orderItemsToAdd,
           }
         )
         .then((res: any) => {

--- a/node/resolvers/mutations/index.ts
+++ b/node/resolvers/mutations/index.ts
@@ -595,7 +595,7 @@ export const Mutation = {
       // them as new items instead of updating existing ones - which is the
       // intent here, since the cart was cleared above.
       const data = await hub.patch(
-        `${routes.addToCart(account, orderFormId)}${salesChannelQueryString}`,
+        `${routes.cartItems(account, orderFormId)}${salesChannelQueryString}`,
         {
           expectedOrderFormSections: ['items'],
           orderItems: orderItemsToAdd,
@@ -625,16 +625,27 @@ export const Mutation = {
 
         quoteItemIndex++
         const sellingData = sellingPriceMap[String(quoteItemIndex)]
+        const priceToken = priceTokens[priceTokenKey(item.id, item.seller)]
 
         orderItems.push({
+          // `id` and `seller` are required by PATCH /items, unlike the
+          // POST /items/update this call used to make.
+          id: item.id,
+          seller: item.seller,
           index: realIndex,
           price: sellingData?.price,
           quantity: sellingData?.quantity,
+          ...(priceToken ? { priceToken } : {}),
         })
       })
 
-      await hub.post(
-        routes.addPriceToItems(account, orderFormId),
+      // APPLY THE NEGOTIATED PRICE
+      // Sending `index` is what makes PATCH change the existing items instead
+      // of adding new ones. This replaced POST /items/update, which does not
+      // honor `priceToken` either - so during a Pricing outage the price
+      // override would have failed even with the items already in the cart.
+      await hub.patch(
+        routes.cartItems(account, orderFormId),
         {
           orderItems,
         },

--- a/node/resolvers/mutations/index.ts
+++ b/node/resolvers/mutations/index.ts
@@ -590,17 +590,17 @@ export const Mutation = {
       })
 
       // ADD ITEMS TO CART
-      const data = await hub
-        .post(
-          `${routes.addToCart(account, orderFormId)}${salesChannelQueryString}`,
-          {
-            expectedOrderFormSections: ['items'],
-            orderItems: orderItemsToAdd,
-          }
-        )
-        .then((res: any) => {
-          return res.data
-        })
+      // PATCH, not POST: only PATCH honors `priceToken`, and POST is no longer
+      // meant to be used. Omitting `index` on the items is what makes PATCH add
+      // them as new items instead of updating existing ones - which is the
+      // intent here, since the cart was cleared above.
+      const data = await hub.patch(
+        `${routes.addToCart(account, orderFormId)}${salesChannelQueryString}`,
+        {
+          expectedOrderFormSections: ['items'],
+          orderItems: orderItemsToAdd,
+        }
+      )
 
       const { items: itemsAdded } = data
 

--- a/node/resolvers/utils/priceTokens.ts
+++ b/node/resolvers/utils/priceTokens.ts
@@ -1,0 +1,66 @@
+import { splitEvery, uniq, unnest } from 'ramda'
+
+import { CATALOG_SEARCH_PAGE_SIZE } from '../../constants'
+
+export const priceTokenKey = (skuId: string, seller: string) =>
+  `${skuId}-${seller}`
+
+/**
+ * Fetches the signed prices (`priceToken`) for the given SKUs.
+ *
+ * The `useQuote` flow applies items stored in Master Data, so there is no live
+ * search to reuse a token from - we have to ask the catalog search for a fresh
+ * one at the moment the quote is applied. Sending the token to
+ * `POST /orderForm/{id}/items` lets Checkout add the items even when Pricing is
+ * unavailable. The negotiated price is still applied afterwards through
+ * `PUT /orderForm/{id}/items/update`, so the token never changes the final
+ * price charged.
+ *
+ * The token is optional by design: the field is behind a feature flag on the
+ * search API, and this whole call is a resilience improvement. Any failure is
+ * logged and ignored, keeping the previous behavior of adding items without a
+ * token.
+ */
+export const getPriceTokens = async (
+  ctx: Context,
+  { skuIds, salesChannel }: { skuIds: string[]; salesChannel?: string | null }
+): Promise<Record<string, string>> => {
+  const {
+    clients: { catalog },
+    vtex: { logger },
+  } = ctx
+
+  const priceTokens: Record<string, string> = {}
+
+  if (!skuIds.length) return priceTokens
+
+  try {
+    const batches = splitEvery(CATALOG_SEARCH_PAGE_SIZE, uniq(skuIds))
+
+    const products = unnest(
+      await Promise.all(
+        batches.map((batch) => catalog.searchBySkuIds(batch, salesChannel))
+      )
+    )
+
+    for (const product of products) {
+      for (const item of product?.items ?? []) {
+        for (const seller of item?.sellers ?? []) {
+          const priceToken = seller?.commertialOffer?.PriceToken
+
+          if (priceToken) {
+            priceTokens[priceTokenKey(item.itemId, seller.sellerId)] =
+              priceToken
+          }
+        }
+      }
+    }
+  } catch (error) {
+    logger.warn({
+      error,
+      message: 'getPriceTokens-catalogSearchError',
+    })
+  }
+
+  return priceTokens
+}

--- a/node/resolvers/utils/priceTokens.ts
+++ b/node/resolvers/utils/priceTokens.ts
@@ -21,9 +21,17 @@ export const priceTokenKey = (skuId: string, seller: string) =>
  * improvement. Any failure is logged and ignored, keeping the previous behavior
  * of adding items without a token.
  *
- * The raw search API returns the field as `PriceToken` (PascalCase), while
- * `search-graphql` exposes it as `priceToken`. Both are accepted so the reader
- * does not depend on which one answers the request.
+ * The field is `PriceToken` (PascalCase) here because this reads the Catalog
+ * Search REST API. Do not switch to the camelCase `priceToken`: that name only
+ * exists in `vtex.search-graphql`, which maps the REST field - reading
+ * PascalCase from a search-graphql query is a known source of bugs.
+ *
+ * The token is a JWT signed by `session/data-signer`, valid for 30 minutes,
+ * whose claims bind the price to `{ id, seller, accountName, salesChannel }` -
+ * hence the sales channel must be forwarded to the search, so the token is not
+ * bound to a channel other than the one the item is added on. When the quote
+ * carries no sales channel, the search resolves it to the account default, the
+ * same one `addToCart` falls back to.
  */
 export const getPriceTokens = async (
   ctx: Context,
@@ -50,9 +58,7 @@ export const getPriceTokens = async (
     for (const product of products) {
       for (const item of product?.items ?? []) {
         for (const seller of item?.sellers ?? []) {
-          const { commertialOffer } = seller ?? {}
-          const priceToken =
-            commertialOffer?.PriceToken ?? commertialOffer?.priceToken
+          const priceToken = seller?.commertialOffer?.PriceToken
 
           if (priceToken) {
             priceTokens[priceTokenKey(item.itemId, seller.sellerId)] =

--- a/node/resolvers/utils/priceTokens.ts
+++ b/node/resolvers/utils/priceTokens.ts
@@ -61,8 +61,9 @@ export const getPriceTokens = async (
           const priceToken = seller?.commertialOffer?.PriceToken
 
           if (priceToken) {
-            priceTokens[priceTokenKey(item.itemId, seller.sellerId)] =
-              priceToken
+            priceTokens[
+              priceTokenKey(item.itemId, seller.sellerId)
+            ] = priceToken
           }
         }
       }

--- a/node/resolvers/utils/priceTokens.ts
+++ b/node/resolvers/utils/priceTokens.ts
@@ -16,10 +16,14 @@ export const priceTokenKey = (skuId: string, seller: string) =>
  * `PUT /orderForm/{id}/items/update`, so the token never changes the final
  * price charged.
  *
- * The token is optional by design: the field is behind a feature flag on the
- * search API, and this whole call is a resilience improvement. Any failure is
- * logged and ignored, keeping the previous behavior of adding items without a
- * token.
+ * The token is optional by design: it is only used when Pricing is down, it is
+ * behind a feature flag on the search API, and this whole call is a resilience
+ * improvement. Any failure is logged and ignored, keeping the previous behavior
+ * of adding items without a token.
+ *
+ * The raw search API returns the field as `PriceToken` (PascalCase), while
+ * `search-graphql` exposes it as `priceToken`. Both are accepted so the reader
+ * does not depend on which one answers the request.
  */
 export const getPriceTokens = async (
   ctx: Context,
@@ -46,7 +50,9 @@ export const getPriceTokens = async (
     for (const product of products) {
       for (const item of product?.items ?? []) {
         for (const seller of item?.sellers ?? []) {
-          const priceToken = seller?.commertialOffer?.PriceToken
+          const { commertialOffer } = seller ?? {}
+          const priceToken =
+            commertialOffer?.PriceToken ?? commertialOffer?.priceToken
 
           if (priceToken) {
             priceTokens[priceTokenKey(item.itemId, seller.sellerId)] =

--- a/node/resolvers/utils/priceTokens.ts
+++ b/node/resolvers/utils/priceTokens.ts
@@ -11,7 +11,7 @@ export const priceTokenKey = (skuId: string, seller: string) =>
  * The `useQuote` flow applies items stored in Master Data, so there is no live
  * search to reuse a token from - we have to ask the catalog search for a fresh
  * one at the moment the quote is applied. Sending the token to
- * `POST /orderForm/{id}/items` lets Checkout add the items even when Pricing is
+ * `PATCH /orderForm/{id}/items` lets Checkout add the items even when Pricing is
  * unavailable. The negotiated price is still applied afterwards through
  * `PUT /orderForm/{id}/items/update`, so the token never changes the final
  * price charged.

--- a/node/resolvers/utils/priceTokens.ts
+++ b/node/resolvers/utils/priceTokens.ts
@@ -11,10 +11,10 @@ export const priceTokenKey = (skuId: string, seller: string) =>
  * The `useQuote` flow applies items stored in Master Data, so there is no live
  * search to reuse a token from - we have to ask the catalog search for a fresh
  * one at the moment the quote is applied. Sending the token to
- * `PATCH /orderForm/{id}/items` lets Checkout add the items even when Pricing is
- * unavailable. The negotiated price is still applied afterwards through
- * `PUT /orderForm/{id}/items/update`, so the token never changes the final
- * price charged.
+ * `PATCH /orderForm/{id}/items` lets Checkout build the cart even when Pricing
+ * is unavailable. `useQuote` calls that route twice: once without `index` to add
+ * the items, then again with `index` to overwrite the price with the negotiated
+ * one - so the token never changes the final price charged.
  *
  * The token is optional by design: it is only used when Pricing is down, it is
  * behind a feature flag on the search API, and this whole call is a resilience

--- a/node/typings.d.ts
+++ b/node/typings.d.ts
@@ -161,3 +161,26 @@ interface Seller {
   id: string
   name: string
 }
+
+interface CatalogCommertialOffer {
+  Price: number
+  ListPrice: number
+  // Signed price generated per search request, valid for 30 minutes. Only
+  // returned by accounts where the Pricing Fallback feature flag is enabled.
+  PriceToken?: string
+}
+
+interface CatalogSeller {
+  sellerId: string
+  commertialOffer: CatalogCommertialOffer
+}
+
+interface CatalogItem {
+  itemId: string
+  sellers: CatalogSeller[]
+}
+
+interface CatalogProduct {
+  productId: string
+  items: CatalogItem[]
+}

--- a/node/typings.d.ts
+++ b/node/typings.d.ts
@@ -166,11 +166,10 @@ interface CatalogCommertialOffer {
   Price: number
   ListPrice: number
   // Signed price generated per search request, valid for 30 minutes. Only
-  // returned by accounts where the Pricing Fallback feature flag is enabled.
-  // The raw search API returns it as `PriceToken`; `search-graphql` exposes the
-  // same value as `priceToken`.
+  // returned by accounts where the price signing feature flag is enabled.
+  // PascalCase is the name used by the Catalog Search REST API; the camelCase
+  // `priceToken` only exists in `vtex.search-graphql`.
   PriceToken?: string
-  priceToken?: string
 }
 
 interface CatalogSeller {

--- a/node/typings.d.ts
+++ b/node/typings.d.ts
@@ -167,7 +167,10 @@ interface CatalogCommertialOffer {
   ListPrice: number
   // Signed price generated per search request, valid for 30 minutes. Only
   // returned by accounts where the Pricing Fallback feature flag is enabled.
+  // The raw search API returns it as `PriceToken`; `search-graphql` exposes the
+  // same value as `priceToken`.
   PriceToken?: string
+  priceToken?: string
 }
 
 interface CatalogSeller {

--- a/node/utils/Hub.ts
+++ b/node/utils/Hub.ts
@@ -37,6 +37,14 @@ export default class RequestHub extends ExternalClient {
     })
   }
 
+  // Unlike the methods above there is no `patchRaw`, so this resolves to the
+  // response body instead of the whole response.
+  public patch(url: string, data: any, headers?: any) {
+    return this.http.patch<any>(url, data, {
+      headers,
+    })
+  }
+
   public delete(url: string) {
     return this.http.delete(url)
   }

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -591,10 +591,10 @@
   resolved "https://registry.yarnpkg.com/@types/shimmer/-/shimmer-1.2.0.tgz#9b706af96fa06416828842397a70dfbbf1c14ded"
   integrity sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==
 
-"@vtex/api@6.51.0":
-  version "6.51.0"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.51.0.tgz#97aeb306619ff49fd890595b90568883eaf77d83"
-  integrity sha512-vRWKB4G1FPPt67rwWx+xGLanuP5y+M9SVmbKu3PzlTrqgq/aW/mINSUGa/Nhm64UBqIQCkVic7/smZ7kKFq52w==
+"@vtex/api@6.50.1":
+  version "6.50.1"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.50.1.tgz#a86578982a7aac7c7a8df2b9ec3df18bc43f01f2"
+  integrity sha512-4IlmYwCXKpkdpN2KN6NkPuRwnjet3ilSoET3PBOTTdZqE/mnuvIxRZRaQy+Yp7Gxu0XKAVdp/8SQJhsJaa6Unw==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -2254,7 +2254,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.1"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/a0b5ee91861f31b6ec845146b4906faf5172c430"
   dependencies:

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -591,10 +591,10 @@
   resolved "https://registry.yarnpkg.com/@types/shimmer/-/shimmer-1.2.0.tgz#9b706af96fa06416828842397a70dfbbf1c14ded"
   integrity sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==
 
-"@vtex/api@6.50.1":
-  version "6.50.1"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.50.1.tgz#a86578982a7aac7c7a8df2b9ec3df18bc43f01f2"
-  integrity sha512-4IlmYwCXKpkdpN2KN6NkPuRwnjet3ilSoET3PBOTTdZqE/mnuvIxRZRaQy+Yp7Gxu0XKAVdp/8SQJhsJaa6Unw==
+"@vtex/api@6.51.0":
+  version "6.51.0"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.51.0.tgz#97aeb306619ff49fd890595b90568883eaf77d83"
+  integrity sha512-vRWKB4G1FPPt67rwWx+xGLanuP5y+M9SVmbKu3PzlTrqgq/aW/mINSUGa/Nhm64UBqIQCkVic7/smZ7kKFq52w==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -2254,7 +2254,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.1"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/a0b5ee91861f31b6ec845146b4906faf5172c430"
   dependencies:


### PR DESCRIPTION
#### What problem is this solving?

[B2BTEAM-3733](https://vtex-dev.atlassian.net/browse/B2BTEAM-3733) — Pricing Fallback V2.

The `useQuote` mutation applies a quote to the cart by adding the items with `{ id, seller, quantity }` and only then overwrites the price with the negotiated value in a second call. Since the final price is already overwritten manually, a `priceToken` does not affect the amount charged — but the initial `addToCart` call can still fail if Pricing is unavailable, blocking the application of already-approved quotes during an incident.

**Evaluation (the "avaliar" part of the ticket):** unlike the standard flow (Portal/SF/FS/quickorder), `useQuote` has no live search to reuse a `PriceToken` from — items come from a Master Data record. Persisting the token with the quote is not viable either: it is valid for 30 minutes while a quote lives for days. The remaining option is to fetch a fresh signed price at the moment the quote is applied, treating the token as **optional**.

**What this PR does:**

- Adds a `Catalog` client (`JanusClient`) that queries `GET /api/catalog_system/pub/products/search?fq=skuId:…&sc=…`. This is the exact endpoint where price signing was delivered in part 1 of the initiative ([vtex/catalog-search#445](https://github.com/vtex/catalog-search/pull/445)), returning `items[].sellers[].commertialOffer.PriceToken`. Configured with `retries: 1` and `timeout: 3000` so it never weighs on the critical path.
- Forwards the quote's sales channel to the search, because it is part of the signed claims (see the validation below).
- Adds `getPriceTokens`, which batches 50 SKUs per request, builds a `${skuId}-${seller} → token` map, and **swallows any failure** (`logger.warn` + empty map). It reads `PriceToken` (PascalCase), which is the name used by the Catalog Search REST API — the camelCase `priceToken` only exists in `vtex.search-graphql`, which maps the REST field.
- **Moves both cart operations to `PATCH /orderForm/{id}/items`.** Confirmed in the thread that neither `POST /items` nor `POST /items/update` honors `priceToken`, and that `PATCH` is meant to be the only route used. Adding the items sends no `index`; overwriting the price sends `index`. The price payload gains `id` and `seller`, which `PATCH` requires and the old `/items/update` did not, and it carries `priceToken` too — otherwise a Pricing outage would still break `useQuote` on the second call, with the items already in the cart. `routes.addToCart` and `routes.addPriceToItems` collapse into one `routes.cartItems`. `RequestHub` gains a `patch` method (there is no `patchRaw` in `@vtex/api`, so it resolves to the body and the call site no longer unwraps `.data`).
- `useQuote` attaches `priceToken` to each `orderItem` when one is available. With no token, the payload is what it is today.
- The price override still runs afterwards, so the negotiated price remains the one charged — the token never changes any value.
- Logs `useQuote-priceTokenCoverage` (items with/without token, plus the sales channel). Neither the `addToCart` response nor the `orderForm` reports whether the token was received or used, and the fallback only activates during a Pricing outage — so this log is the only practical evidence that tokens are getting through, short of simulating an outage.
- Adds the `outbound-access` policy for `/api/catalog_system/pub/*`, catalog typings, and a CHANGELOG entry.

#### Validation on `b2bstoreqa` (price signing flag enabled)

Read-only `GET`s against the account confirm the two assumptions this PR rests on:

| Request | `PriceToken` present | `salesChannel` claim | `exp - iat` |
| --- | --- | --- | --- |
| `intelligent-search/v1/product-search?an=b2bstoreqa&sc=1` | yes | — | — |
| `catalog_system/pub/products/search?fq=skuId:…&sc=1` | yes | `"1"` | 1800s |
| `catalog_system/pub/products/search?fq=skuId:…` (no `sc`) | yes | `"1"` | 1800s |
| `catalog_system/pub/products/search?fq=skuId:…&sc=2` | empty result — no token | — | — |

1. **The endpoint this app uses does return the token.** Price signing on the Catalog Search REST API came with part 1 of the initiative, independently of the `intsch` work.
2. **The token is a JWT** signed by `session/data-signer`, 30 minutes of validity, with claims `{ price, priceWithoutDiscount, seller, id, accountName, salesChannel }`. The signed price is the catalog price, not the negotiated one — which is consistent with this flow: the token only has to get the item into the cart, and the second call then applies the negotiated price as a manual price change.
3. **The sales channel is part of the claims**, so it must be forwarded to the search — it is. Without `sc` the search resolves it to the account default (`"1"`), the same default `addToCart` falls back to when the quote carries no sales channel.
4. If the SKU is not in the quote's sales channel the search simply returns nothing, and the flow proceeds with no token.

#### End-to-end evidence (workspace `b2bstoreqa/pricetoken`)

Quote applied through the storefront's "Use quote" button with the app linked. From OpenSearch:

```json
{"level":"info","app":"vtex.b2b-quotes-graphql@4.0.6","account":"b2bstoreqa","workspace":"pricetoken",
 "data":{"message":"useQuote-priceTokenCoverage","itemsWithPriceToken":1,"totalItems":1,"salesChannel":"1"}}
```

Confirms, from inside the IO service: the catalog search succeeds (no `getPriceTokens-catalogSearchError`), the `${skuId}-${seller}` mapping matches, the sales channel is forwarded, and every item leaves with a token. Note `useQuote` resolves to `null` on success by design (the resolver has no return value), so the mutation response carries no signal — this log is the signal.

That run predates the move to `PATCH`, so it validates the token plumbing but not the current routes. Still to exercise: a multi-SKU, multi-seller quote (stronger test of the composite key and of the index mapping), the 50-SKU batching, and the degradation path.

#### How to test it?

[Workspace](Link goes here!)

1. Link the branch to a workspace on an account where the Pricing Fallback feature flag is **enabled** on the search API (`b2bstoreqa` was requested for B2B validation; `storeframework` is the FastStore test store).
2. Create and approve a quote, then apply it with `useQuote`.
3. Confirm the `useQuote-priceTokenCoverage` log shows `itemsWithPriceToken == totalItems`.
4. Confirm the cart ends up with the **negotiated** prices (the token must not change the final price).
5. On an account **without** the flag, confirm `useQuote` behaves exactly as before (no token in the payload, no error).
6. **Regression from the route change (`POST /items` and `POST /items/update` → `PATCH /items`)** — the main thing to exercise now, and none of it needs Pricing to be down:
   - **Prices land on the right items.** Use a quote with 3+ SKUs at clearly different negotiated prices and check each cart line. The index mapping (`itemsAdded.forEach` + the `isGift` skip + the parallel `quoteItemIndex` counter) assumes the cart returns items in the same order as the quote; if `PATCH` reorders or consolidates them, the wrong item gets the wrong price. This is a charged-value bug, not a resilience one, and it is the pre-existing fragility most exposed by this change.
   - Quantities are right, with no merged or duplicated lines.
   - A multi-seller quote applies correctly (exercises the `${skuId}-${seller}` key).
   - A quote whose `salesChannel` is not the account default lands on the right channel — `?sc=` is undocumented on `PATCH`, so confirm it is still honored.

> Per the thread, the fallback only kicks in during an actual Pricing incident, so an end-to-end validation means intentionally opening the circuit with Pricing and checking orders still close. Sending the field is the testable part here.

#### Screenshots or example usage:

N/A — backend only.

#### Describe alternatives you've considered, if any.

- **Persisting the `PriceToken` alongside the quote in Master Data:** discarded, the token expires in 30 minutes while quotes live for days.
- **Reading the token through `search-graphql`:** it is exposed there since `search-graphql@0.72.0`, but that would add an app dependency and a GraphQL round trip to a backend-only flow. The raw Catalog Search API is where the field originates and needs no app dependency.
- **Doing nothing:** valid fallback. There is no functional break today nor expected with the feature launch — this is purely a resilience improvement for applying quotes during Pricing outages.

#### Points that need a decision before release

1. ~~Whether `POST /items` honors the token.~~ **Answered:** neither `POST /items` nor `POST /items/update` does — only `PATCH /items`, which is meant to be the only route used. Both calls were migrated, so the review focus moves to that change; the remaining risk is behavioral rather than about the token, and item #6 under "How to test it?" covers it.
2. **Optional simplification, not in this PR:** `PATCH /items` accepts `price` on insert, so the two calls could in principle collapse into one and the index mapping would disappear entirely. That is a redesign rather than an adaptation, and it needs confirmation that Checkout accepts a manual price at insert time — worth its own ticket if the index mapping keeps causing trouble.
3. **The new `outbound-access` policy requires merchants to re-accept app permissions** on update. If that is undesirable right now, we can hold the merge until the field leaves the feature flag.
4. Extra call in the `useQuote` path: one catalog search (cached, ~10 min API Cache) before `addToCart`. Bounded by `timeout: 3000` / `retries: 1` and fully non-blocking on failure.
5. There is no unit test infrastructure in this repo (Cypress only, via `cy-runner`), so no automated tests were added.

#### Not blocking this PR

`vtex.checkout-graphql`'s `ItemInput` has no `priceToken` field ([vtex-apps/checkout-graphql#219](https://github.com/vtex-apps/checkout-graphql/pull/219)), which blocks the apps that add to cart through the GraphQL mutation — `sku-list` ([B2BTEAM-3748](https://vtex-dev.atlassian.net/browse/B2BTEAM-3748)) and `quickorder`. This app talks to the Checkout REST API directly, so it does not depend on that fix and can move on its own.

Worth flagging to those apps, though: since `POST /items` does not honor the token, adding `priceToken` to `ItemInput` is necessary but may not be sufficient — whatever `checkout-graphql` calls underneath has to be `PATCH` too.

#### Related to / Depends on

- Reference thread: https://vtex.slack.com/archives/C07N5C1GWCB/p1764774437017629
- Part 1 (already in production): [catalog-search#445](https://github.com/vtex/catalog-search/pull/445) (signing), [vcs.checkout#6134](https://github.com/vtex/vcs.checkout/pull/6134) and [sales-order-system#940](https://github.com/vtex/sales-order-system/pull/940) (reading), [vcs.commerce#2329](https://github.com/vtex/vcs.commerce/pull/2329) (Portal).
- Depends on the price signing feature flag being enabled for the account — it is currently limited to test stores.
- Sibling B2B work: `sku-list` ([B2BTEAM-3748](https://vtex-dev.atlassian.net/browse/B2BTEAM-3748)) and `quickorder`, both blocked on `checkout-graphql`.

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media.giphy.com/media/l0HlPystfePnAI3G8/giphy.gif)


[B2BTEAM-3733]: https://vtex-dev.atlassian.net/browse/B2BTEAM-3733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[B2BTEAM-3748]: https://vtex-dev.atlassian.net/browse/B2BTEAM-3748?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ